### PR TITLE
Signer proofs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "tabWidth": 2,
-  "printWidth": 120
+  "printWidth": 80
 }

--- a/contracts/SignHash.sol
+++ b/contracts/SignHash.sol
@@ -5,8 +5,11 @@ contract SignHash {
 
     //--- Storage
 
+    // hash to signers
     mapping (bytes32 => address[]) private hashSigners;
-    mapping (address => mapping (string => string)) private signerProofs;
+
+    // signer to proofs (method to value)
+    mapping (address => mapping (string => string)) private proofs;
 
     //--- Constructor
 
@@ -14,8 +17,8 @@ contract SignHash {
 
     //--- Events
 
-    event HashSigned(bytes32 indexed hash, address indexed signer);
-    event SignerProved(address indexed signer, string method, string value);
+    event Signed(bytes32 indexed hash, address indexed signer);
+    event ProofAdded(address indexed signer, string method, string value);
 
     //--- Public mutable functions
 
@@ -25,25 +28,33 @@ contract SignHash {
         address[] storage signers = hashSigners[hash];
         signers.push(msg.sender);
 
-        HashSigned(hash, msg.sender);
+        Signed(hash, msg.sender);
     }
 
-    function prove(string method, string value) {
+    function addProof(string method, string value) {
         require(bytes(method).length > 0);
         require(bytes(value).length > 0);
 
-        signerProofs[msg.sender][method] = value;
+        proofs[msg.sender][method] = value;
 
-        SignerProved(msg.sender, method, value);
+        ProofAdded(msg.sender, method, value);
     }
 
     //--- Public constant functions
 
-    function getSigners(bytes32 hash) public constant returns (address[]) {
+    function getSigners(bytes32 hash)
+        public
+        constant
+        returns (address[])
+    {
         return hashSigners[hash];
     }
 
-    function getProof(address signer, string method) public constant returns (string) {
-        return signerProofs[signer][method];
+    function getProof(address signer, string method)
+        public
+        constant
+        returns (string)
+    {
+        return proofs[signer][method];
     }
 }

--- a/contracts/SignHash.sol
+++ b/contracts/SignHash.sol
@@ -6,6 +6,7 @@ contract SignHash {
     //--- Storage
 
     mapping (bytes32 => address[]) private hashSigners;
+    mapping (address => mapping (string => string)) private signerProofs;
 
     //--- Constructor
 
@@ -14,6 +15,7 @@ contract SignHash {
     //--- Events
 
     event HashSigned(bytes32 indexed hash, address indexed signer);
+    event SignerProved(address indexed signer, string method, string value);
 
     //--- Public mutable functions
 
@@ -26,9 +28,22 @@ contract SignHash {
         HashSigned(hash, msg.sender);
     }
 
+    function prove(string method, string value) {
+        require(bytes(method).length > 0);
+        require(bytes(value).length > 0);
+
+        signerProofs[msg.sender][method] = value;
+
+        SignerProved(msg.sender, method, value);
+    }
+
     //--- Public constant functions
 
     function getSigners(bytes32 hash) public constant returns (address[]) {
         return hashSigners[hash];
+    }
+
+    function getProof(address signer, string method) public constant returns (string) {
+        return signerProofs[signer][method];
     }
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,3 +1,8 @@
+declare interface Web3 {
+  toAscii(hex: string): string;
+  fromAscii(ascii: string, padding?: number): string;
+}
+
 declare interface Contract<T> {
   address: string;
   deployed(): Promise<T>;
@@ -77,3 +82,4 @@ interface ContractContextDefinition extends Mocha.IContextDefinition {
 declare var artifacts: Artifacts;
 declare var contract: ContractContextDefinition;
 declare var assert: Chai.Assert;
+declare var web3: Web3;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -32,7 +32,7 @@ declare type TransactionLog = {
   blockHash: string;
   blockNumber: number;
   address: string;
-  type: 'mined';
+  type: string;
   event: string;
   args: any;
 };
@@ -53,12 +53,20 @@ declare interface SignHashContract extends Contract<SignHash> {
 
 declare interface SignHash {
   sign(hash: string, options?: TransactionOptions): Promise<TransactionResult>;
+  prove(method: string, value: string, options?: TransactionOptions): Promise<TransactionResult>;
   getSigners(hash: string): Promise<string[]>;
+  getProof(signer: string, method: string): Promise<string>;
 }
 
 declare interface HashSigned {
   hash: string;
   signer: string;
+}
+
+declare interface SignerProved {
+  signer: string;
+  method: string;
+  value: string;
 }
 
 declare interface Migrations {
@@ -79,7 +87,7 @@ interface ContractContextDefinition extends Mocha.IContextDefinition {
   (description: string, callback: (accounts: string[]) => void): Mocha.ISuite;
 }
 
-declare var artifacts: Artifacts;
-declare var contract: ContractContextDefinition;
-declare var assert: Chai.Assert;
-declare var web3: Web3;
+declare const artifacts: Artifacts;
+declare const contract: ContractContextDefinition;
+declare const assert: Chai.Assert;
+declare const web3: Web3;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -53,8 +53,15 @@ declare interface SignHashContract extends Contract<SignHash> {
 
 declare interface SignHash {
   sign(hash: string, options?: TransactionOptions): Promise<TransactionResult>;
-  prove(method: string, value: string, options?: TransactionOptions): Promise<TransactionResult>;
+
+  prove(
+    method: string,
+    value: string,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
+
   getSigners(hash: string): Promise<string[]>;
+
   getProof(signer: string, method: string): Promise<string>;
 }
 
@@ -70,8 +77,15 @@ declare interface SignerProved {
 }
 
 declare interface Migrations {
-  setCompleted(completed: number, options?: TransactionOptions): Promise<TransactionResult>;
-  upgrade(address: string, options?: TransactionOptions): Promise<TransactionResult>;
+  setCompleted(
+    completed: number,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
+
+  upgrade(
+    address: string,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
 }
 
 declare interface Artifacts {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -54,7 +54,7 @@ declare interface SignHashContract extends Contract<SignHash> {
 declare interface SignHash {
   sign(hash: string, options?: TransactionOptions): Promise<TransactionResult>;
 
-  prove(
+  addProof(
     method: string,
     value: string,
     options?: TransactionOptions
@@ -65,12 +65,12 @@ declare interface SignHash {
   getProof(signer: string, method: string): Promise<string>;
 }
 
-declare interface HashSigned {
+declare interface Signed {
   hash: string;
   signer: string;
 }
 
-declare interface SignerProved {
+declare interface ProofAdded {
   signer: string;
   method: string;
   value: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,12 +224,6 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
-    "bignumber.js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==",
-      "dev": true
-    },
     "binary-extensions": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
@@ -3540,15 +3534,6 @@
         "async": "2.5.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
-      }
-    },
-    "web3-typescript-typings": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/web3-typescript-typings/-/web3-typescript-typings-0.6.0.tgz",
-      "integrity": "sha512-AArPikyQbsuVHsx7jQGGoPtKOnA5NnAhms88YH70GomJQcwf9OiAjF2tX6MGZhqQgNl4T3G75XmxdL23oa41Og==",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "4.0.4"
       }
     },
     "webpack": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ramda": "^0.24.1",
     "solium": "^0.5.5",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.2",
-    "web3-typescript-typings": "^0.6.0"
+    "typescript": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "SignHash smart contracts",
   "scripts": {
     "compile": "npm-run-all compile:ts compile:sol",
-    "compile:sol": "truffle compile --contracts_build_directory .cache/contracts",
+    "compile:sol":
+      "truffle compile --contracts_build_directory .cache/contracts",
     "compile:ts": "tsc",
     "test": "npm-run-all compile test:run",
     "test:run": "truffle test --contracts_build_directory .cache/contracts",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,16 +7,16 @@ export async function assertThrowsInvalidOpcode(func: () => void) {
     assertInvalidOpcode(error);
     return;
   }
-  assert.fail({}, {}, 'Should have thrown');
+  assert.fail({}, {}, 'Should have thrown Invalid Opcode');
 }
 
 export function assertInvalidOpcode(error: { message: string }) {
   if (error && error.message) {
     if (error.message.search('invalid opcode') === -1) {
-      assert.fail(error, {}, 'Invalid opcode error must be returned, got: ' + error.message);
+      assert.fail(error, {}, 'Expected Invalid Opcode error, instead got: ' + error.message);
     }
   } else {
-    assert.fail(error, {}, 'Expected to throw an error');
+    assert.fail(error, {}, 'Expected Invalid Opcode error');
   }
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -13,13 +13,20 @@ export async function assertThrowsInvalidOpcode(func: () => void) {
 export function assertInvalidOpcode(error: { message: string }) {
   if (error && error.message) {
     if (error.message.search('invalid opcode') === -1) {
-      assert.fail(error, {}, 'Expected Invalid Opcode error, instead got: ' + error.message);
+      assert.fail(
+        error,
+        {},
+        'Expected Invalid Opcode error, instead got: ' + error.message
+      );
     }
   } else {
     assert.fail(error, {}, 'Expected Invalid Opcode error');
   }
 }
 
-export function findLastLog(trans: TransactionResult, event: string): TransactionLog {
+export function findLastLog(
+  trans: TransactionResult,
+  event: string
+): TransactionLog {
   return findLast(propEq('event', event))(trans.logs);
 }

--- a/test/signhash.ts
+++ b/test/signhash.ts
@@ -35,11 +35,11 @@ contract('SignHash', accounts => {
       forEach(i => assert.isTrue(contains(accounts[i], signers)), seq);
     });
 
-    it('should emit HashSigned event', async () => {
+    it('should emit Signed event', async () => {
       const signer = accounts[0];
       const trans = await instance.sign(HASH, { from: signer });
-      const log = findLastLog(trans, 'HashSigned');
-      const event: HashSigned = log.args;
+      const log = findLastLog(trans, 'Signed');
+      const event: Signed = log.args;
 
       assert.equal(event.hash, HASH);
       assert.equal(event.signer, signer);
@@ -53,12 +53,12 @@ contract('SignHash', accounts => {
     });
   });
 
-  describe('#prove', () => {
+  describe('#addProof', () => {
     it('should add proof', async () => {
       const signer = accounts[0];
       const method = 'http';
       const value = 'example.com';
-      await instance.prove(method, value, { from: signer });
+      await instance.addProof(method, value, { from: signer });
 
       const proof = await instance.getProof(signer, method);
       assert.equal(proof, value);
@@ -83,7 +83,7 @@ contract('SignHash', accounts => {
 
       await Promise.all(
         proofs.map(proof =>
-          instance.prove(proof.method, proof.value, { from: signer })
+          instance.addProof(proof.method, proof.value, { from: signer })
         )
       );
 
@@ -102,20 +102,20 @@ contract('SignHash', accounts => {
       const method = 'http';
       const value = 'example.com';
       const newValue = 'another.com';
-      await instance.prove(method, value, { from: signer });
-      await instance.prove(method, newValue, { from: signer });
+      await instance.addProof(method, value, { from: signer });
+      await instance.addProof(method, newValue, { from: signer });
 
       const proof = await instance.getProof(signer, method);
       assert.equal(proof, newValue);
     });
 
-    it('should emit SignerProved event', async () => {
+    it('should emit ProofAdded event', async () => {
       const signer = accounts[0];
       const method = 'http';
       const value = 'example.com';
-      const trans = await instance.prove(method, value, { from: signer });
-      const log = findLastLog(trans, 'SignerProved');
-      const event: SignerProved = log.args;
+      const trans = await instance.addProof(method, value, { from: signer });
+      const log = findLastLog(trans, 'ProofAdded');
+      const event: ProofAdded = log.args;
 
       assert.equal(event.signer, signer);
       assert.equal(event.method, method);
@@ -128,7 +128,7 @@ contract('SignHash', accounts => {
       const value = 'test';
 
       await assertThrowsInvalidOpcode(async () => {
-        await instance.prove(method, value, { from: signer });
+        await instance.addProof(method, value, { from: signer });
       });
     });
 
@@ -138,7 +138,7 @@ contract('SignHash', accounts => {
       const value = '';
 
       await assertThrowsInvalidOpcode(async () => {
-        await instance.prove(method, value, { from: signer });
+        await instance.addProof(method, value, { from: signer });
       });
     });
   });

--- a/test/signhash.ts
+++ b/test/signhash.ts
@@ -1,4 +1,4 @@
-import { range, forEach, contains } from 'ramda';
+import { contains, forEach, range } from 'ramda';
 import { assertThrowsInvalidOpcode, findLastLog } from './helpers';
 
 const SignHashContract = artifacts.require('./SignHash.sol');
@@ -40,12 +40,13 @@ contract('SignHash', accounts => {
       const event: HashSigned = log.args;
 
       assert.equal(event.hash, HASH);
-      assert.equal(event.signer, accounts[0]);
+      assert.equal(event.signer, signer);
     });
 
     it('should reject empty hash', async () => {
+      const signer = accounts[0];
       await assertThrowsInvalidOpcode(async () => {
-        await instance.sign('', { from: accounts[0] });
+        await instance.sign('', { from: signer });
       });
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es2017",
     "baseUrl": ".",
     "strict": true,
     "typeRoots": ["./node_modules/@types"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,10 @@
     "types": ["bignumber.js", "chai", "mocha"]
   },
   "lib": ["es2015"],
-  "include": ["./truffle.ts", "./globals.d.ts", "./test/**/*", "./migrations/**/*"]
+  "include": [
+    "./truffle.ts",
+    "./globals.d.ts",
+    "./test/**/*",
+    "./migrations/**/*"
+  ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
     "trailing-comma": false,
     "arrow-parens": false,
     "interface-name": [true, "never-prefix"],
-    "interface-over-type-literal": false
+    "interface-over-type-literal": false,
+    "max-line-length": [true, 80]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
This PR introduces idea of `proof`. Each signer can `prove` its identity using multiple methods like `http`, `dns`, `github`. Proofs are not verified by blockchain as it would require interaction with off-chain world. Blockchain serves just as a storage for client applications which verify each of the provided proofs.

It is an open question whether proofs should be iterable. At the moment they are not. They have to be predefined by client applications or restored from emitted events. Introduction of iterable types of proofs for given signer would vastly complicate and increase cost of revoking the proof which is planned to be implemented next.