### PR TITLE
Deduplicate hash signers list

### DIFF
--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -7,11 +7,18 @@ library AddressSet {
         mapping (address => uint256) index; // 1..n, 0 means it does not exists
     }
 
-    function add(Data storage self, address element) {
+    function add(Data storage self, address element) public {
         if (self.index[element] == 0) {
             self.list.push(element);
             self.index[element] = self.list.length;
         }
+    }
+
+    function clear(Data storage self) public {
+        for (uint256 i = 0; i < self.list.length; i++) {
+            delete self.index[self.list[i]];
+        }
+        delete self.list;
     }
 }
 

--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.0;
+
+
+library AddressSet {
+    struct Data {
+        address[] list;
+        mapping (address => uint256) index; // 1..n, 0 means it does not exists
+    }
+
+    function add(Data storage self, address element) {
+        if (self.index[element] == 0) {
+            self.list.push(element);
+            self.index[element] = self.list.length;
+        }
+    }
+}
+

--- a/contracts/SignHash.sol
+++ b/contracts/SignHash.sol
@@ -1,12 +1,18 @@
 pragma solidity ^0.4.0;
 
+import "./AddressSet.sol";
+
 
 contract SignHash {
+
+    //--- Definitions
+
+    using AddressSet for AddressSet.Data;
 
     //--- Storage
 
     // hash to signers
-    mapping (bytes32 => address[]) private hashSigners;
+    mapping (bytes32 => AddressSet.Data) private hashSigners;
 
     // signer to proofs (method to value)
     mapping (address => mapping (string => string)) private proofs;
@@ -26,8 +32,7 @@ contract SignHash {
     function sign(bytes32 hash) {
         require(hash != bytes32(0));
 
-        address[] storage signers = hashSigners[hash];
-        signers.push(msg.sender);
+        hashSigners[hash].add(msg.sender);
 
         Signed(hash, msg.sender);
     }
@@ -59,7 +64,7 @@ contract SignHash {
         constant
         returns (address[])
     {
-        return hashSigners[hash];
+        return hashSigners[hash].list;
     }
 
     function getProof(address signer, string method)

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,12 +4,13 @@ declare interface Web3 {
   sha3(str: string, options?: { encoding: 'hex' }): string;
 }
 
-declare interface Contract<T> {
+declare interface ContractBase {
   address: string;
-  deployed(): Promise<T>;
 }
 
-declare interface Library {}
+declare interface Contract<T> extends ContractBase {
+  deployed(): Promise<T>;
+}
 
 declare type TransactionOptions = {
   from?: string;
@@ -48,6 +49,10 @@ declare type TransactionResult = {
 
 declare interface MigrationsContract extends Contract<Migrations> {
   'new'(options?: TransactionOptions): Promise<Migrations>;
+}
+
+declare interface AddressSetLibrary extends Contract<AddressSet> {
+  'new'(options?: TransactionOptions): Promise<AddressSet>;
 }
 
 declare interface SignHashContract extends Contract<SignHash> {
@@ -101,17 +106,26 @@ declare interface Migrations {
   ): Promise<TransactionResult>;
 }
 
+declare interface AddressSet {
+  get(): Promise<string[]>;
+
+  add(
+    element: string,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
+}
+
 declare interface Artifacts {
   require(name: './Migrations.sol'): MigrationsContract;
-  require(name: './AddressSet.sol'): Library;
+  require(name: './AddressSet.sol'): AddressSetLibrary;
   require(name: './SignHash.sol'): SignHashContract;
 }
 
 declare interface Deployer extends Promise<void> {
-  deploy<T>(object: Contract<T> | Library): Promise<void>;
+  deploy<T>(object: ContractBase): Promise<void>;
   link(
-    library: Library,
-    contracts: Contract<any> | [Contract<any>]
+    library: ContractBase,
+    contracts: ContractBase | [ContractBase]
   ): Promise<void>;
 }
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -9,6 +9,8 @@ declare interface Contract<T> {
   deployed(): Promise<T>;
 }
 
+declare interface Library {}
+
 declare type TransactionOptions = {
   from?: string;
   gas?: number;
@@ -101,11 +103,16 @@ declare interface Migrations {
 
 declare interface Artifacts {
   require(name: './Migrations.sol'): MigrationsContract;
+  require(name: './AddressSet.sol'): Library;
   require(name: './SignHash.sol'): SignHashContract;
 }
 
 declare interface Deployer extends Promise<void> {
-  deploy<T>(contract: Contract<T>): void;
+  deploy<T>(object: Contract<T> | Library): Promise<void>;
+  link(
+    library: Library,
+    contracts: Contract<any> | [Contract<any>]
+  ): Promise<void>;
 }
 
 interface ContractContextDefinition extends Mocha.IContextDefinition {

--- a/migrations/2_deploy_contracts.ts
+++ b/migrations/2_deploy_contracts.ts
@@ -1,6 +1,10 @@
+const AddressSet = artifacts.require('./AddressSet.sol');
 const SignHash = artifacts.require('./SignHash.sol');
 
 async function deploy(deployer: Deployer): Promise<void> {
+  await deployer.deploy(AddressSet);
+  await deployer.link(AddressSet, SignHash);
+
   await deployer.deploy(SignHash);
 }
 

--- a/test/TestAddressSet.sol
+++ b/test/TestAddressSet.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.4.0;
+
+import "truffle/Assert.sol";
+
+import "../contracts/AddressSet.sol";
+
+
+contract TestAddressSet {
+    using AddressSet for AddressSet.Data;
+
+    address address1 = address(1);
+    address address2 = address(2);
+    address address3 = address(3);
+
+    AddressSet.Data set;
+
+    function beforeEach() public {
+        set.clear();
+    }
+
+    function testSetInitiallyEmpty() public {
+        Assert.equal(set.list.length, 0, "List should be empty");
+    }
+
+    function testAdd() public {
+        set.add(address1);
+
+        Assert.equal(set.list.length, 1, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+    }
+
+    function testAddDuplicate() public {
+        set.add(address1);
+
+        Assert.equal(set.list.length, 1, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+    }
+
+    function testAddMultiple() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+
+        Assert.equal(set.list.length, 3, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+        Assert.equal(set.list[2], address3, "Third element should match");
+    }
+
+    function testAddMultipleWithDuplicates() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+        set.add(address2);
+        set.add(address1);
+        set.add(address3);
+        set.add(address2);
+
+        Assert.equal(set.list.length, 3, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+        Assert.equal(set.list[2], address3, "Third element should match");
+    }
+
+    function testClear() public {
+        set.add(address1);
+        set.add(address2);
+
+        set.clear();
+
+        Assert.equal(set.list.length, 0, "List should be empty");
+        Assert.equal(set.index[address1], 0, "Index should not contain the first address");
+        Assert.equal(set.index[address2], 0, "Index should not contain the second address");
+    }
+}

--- a/test/signhash.ts
+++ b/test/signhash.ts
@@ -40,6 +40,14 @@ contract('SignHash', accounts => {
       assert.deepEqual(signers.sort(), accounts.sort());
     });
 
+    it('should add signer only once', async () => {
+      await instance.sign(hash);
+      await instance.sign(hash);
+
+      const signers = await instance.getSigners(hash);
+      assert.deepEqual(signers, [defaultAccount]);
+    });
+
     it('should emit Signed event', async () => {
       const trans = await instance.sign(hash);
       const log = findLastLog(trans, 'Signed');


### PR DESCRIPTION
These changes prevent duplicate entries on hash signers list. It may not be a significant problem but creating `AddressSet` structure will be essential for efficient implementation of `revoke()` function mentioned in #8.