### PR TITLE
Implement revocation mechanism

### DIFF
--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -28,6 +28,7 @@ library AddressSet {
         for (uint256 i = 0; i < self.list.length; i++) {
             delete self.index[self.list[i]];
         }
+
         delete self.list;
     }
 }

--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -7,11 +7,18 @@ library AddressSet {
         mapping (address => uint256) index; // 1..n, 0 means it does not exists
     }
 
-    function add(Data storage self, address element) {
+    function add(Data storage self, address element) public {
         if (self.index[element] == 0) {
             self.list.push(element);
             self.index[element] = self.list.length;
         }
+    }
+
+    function clear(Data storage self) public {
+        for (uint256 i = 0; i < self.list.length; i++) {
+            delete self.index[self.list[i]];
+        }
+        delete self.list;
     }
 }
 

--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -14,6 +14,16 @@ library AddressSet {
         }
     }
 
+    function remove(Data storage self, address element) {
+        uint256 position = self.index[element];
+        if (position != 0) {
+            self.list[position - 1] = self.list[self.list.length - 1];
+            self.list.length--;
+
+            delete self.index[element];
+        }
+    }
+
     function clear(Data storage self) public {
         for (uint256 i = 0; i < self.list.length; i++) {
             delete self.index[self.list[i]];

--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.0;
+
+
+library AddressSet {
+    struct Data {
+        address[] list;
+        mapping (address => uint256) index; // 1..n, 0 means it does not exists
+    }
+
+    function add(Data storage self, address element) {
+        if (self.index[element] == 0) {
+            self.list.push(element);
+            self.index[element] = self.list.length;
+        }
+    }
+}
+

--- a/contracts/AddressSet.sol
+++ b/contracts/AddressSet.sol
@@ -15,11 +15,17 @@ library AddressSet {
     }
 
     function remove(Data storage self, address element) {
+        // preserves initial order of elements, can be optimized if not required
+
         uint256 position = self.index[element];
         if (position != 0) {
-            self.list[position - 1] = self.list[self.list.length - 1];
-            self.list.length--;
+            // position starts from 1
+            while (position < self.list.length) {
+                self.list[position - 1] = self.list[position];
+                position++;
+            }
 
+            self.list.length--;
             delete self.index[element];
         }
     }

--- a/contracts/SignHash.sol
+++ b/contracts/SignHash.sol
@@ -1,12 +1,18 @@
 pragma solidity ^0.4.0;
 
+import "./AddressSet.sol";
+
 
 contract SignHash {
+
+    //--- Definitions
+
+    using AddressSet for AddressSet.Data;
 
     //--- Storage
 
     // hash to signers
-    mapping (bytes32 => address[]) private hashSigners;
+    mapping (bytes32 => AddressSet.Data) private hashSigners;
 
     // signer to proofs (method to value)
     mapping (address => mapping (string => string)) private proofs;
@@ -26,8 +32,7 @@ contract SignHash {
     function sign(bytes32 hash) {
         require(hash != bytes32(0));
 
-        address[] storage signers = hashSigners[hash];
-        signers.push(msg.sender);
+        hashSigners[hash].add(msg.sender);
 
         Signed(hash, msg.sender);
     }
@@ -59,7 +64,7 @@ contract SignHash {
         constant
         returns (address[])
     {
-        return hashSigners[hash];
+        return hashSigners[hash].list;
     }
 
     function getProof(address signer, string method)

--- a/contracts/SignHash.sol
+++ b/contracts/SignHash.sol
@@ -24,6 +24,8 @@ contract SignHash {
     //--- Events
 
     event Signed(bytes32 indexed hash, address indexed signer);
+    event Revoked(bytes32 indexed hash, address indexed signer);
+
     event ProofAdded(address indexed signer, string method, string value);
     event ProofRemoved(address indexed signer, string method);
 
@@ -35,6 +37,14 @@ contract SignHash {
         hashSigners[hash].add(msg.sender);
 
         Signed(hash, msg.sender);
+    }
+
+    function revoke(bytes32 hash) {
+        require(hash != bytes32(0));
+
+        hashSigners[hash].remove(msg.sender);
+
+        Revoked(hash, msg.sender);
     }
 
     function addProof(string method, string value) {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -61,6 +61,10 @@ declare interface SignHashContract extends Contract<SignHash> {
 
 declare interface SignHash {
   sign(hash: string, options?: TransactionOptions): Promise<TransactionResult>;
+  revoke(
+    hash: string,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
 
   addProof(
     method: string,
@@ -79,6 +83,11 @@ declare interface SignHash {
 }
 
 declare interface Signed {
+  hash: string;
+  signer: string;
+}
+
+declare interface Revoked {
   hash: string;
   signer: string;
 }
@@ -119,10 +128,12 @@ declare interface Artifacts {
   require(name: './Migrations.sol'): MigrationsContract;
   require(name: './AddressSet.sol'): AddressSetLibrary;
   require(name: './SignHash.sol'): SignHashContract;
+  require(name: string): ContractBase;
 }
 
 declare interface Deployer extends Promise<void> {
-  deploy<T>(object: ContractBase): Promise<void>;
+  deploy(object: ContractBase): Promise<void>;
+
   link(
     library: ContractBase,
     contracts: ContractBase | [ContractBase]

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,12 +4,13 @@ declare interface Web3 {
   sha3(str: string, options?: { encoding: 'hex' }): string;
 }
 
-declare interface Contract<T> {
+declare interface ContractBase {
   address: string;
-  deployed(): Promise<T>;
 }
 
-declare interface Library {}
+declare interface Contract<T> extends ContractBase {
+  deployed(): Promise<T>;
+}
 
 declare type TransactionOptions = {
   from?: string;
@@ -48,6 +49,10 @@ declare type TransactionResult = {
 
 declare interface MigrationsContract extends Contract<Migrations> {
   'new'(options?: TransactionOptions): Promise<Migrations>;
+}
+
+declare interface AddressSetLibrary extends Contract<AddressSet> {
+  'new'(options?: TransactionOptions): Promise<AddressSet>;
 }
 
 declare interface SignHashContract extends Contract<SignHash> {
@@ -101,17 +106,26 @@ declare interface Migrations {
   ): Promise<TransactionResult>;
 }
 
+declare interface AddressSet {
+  get(): Promise<string[]>;
+
+  add(
+    element: string,
+    options?: TransactionOptions
+  ): Promise<TransactionResult>;
+}
+
 declare interface Artifacts {
   require(name: './Migrations.sol'): MigrationsContract;
-  require(name: './AddressSet.sol'): Library;
+  require(name: './AddressSet.sol'): AddressSetLibrary;
   require(name: './SignHash.sol'): SignHashContract;
 }
 
 declare interface Deployer extends Promise<void> {
-  deploy<T>(object: Contract<T> | Library): Promise<void>;
+  deploy<T>(object: ContractBase): Promise<void>;
   link(
-    library: Library,
-    contracts: Contract<any> | [Contract<any>]
+    library: ContractBase,
+    contracts: ContractBase | [ContractBase]
   ): Promise<void>;
 }
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -9,6 +9,8 @@ declare interface Contract<T> {
   deployed(): Promise<T>;
 }
 
+declare interface Library {}
+
 declare type TransactionOptions = {
   from?: string;
   gas?: number;
@@ -101,11 +103,16 @@ declare interface Migrations {
 
 declare interface Artifacts {
   require(name: './Migrations.sol'): MigrationsContract;
+  require(name: './AddressSet.sol'): Library;
   require(name: './SignHash.sol'): SignHashContract;
 }
 
 declare interface Deployer extends Promise<void> {
-  deploy<T>(contract: Contract<T>): void;
+  deploy<T>(object: Contract<T> | Library): Promise<void>;
+  link(
+    library: Library,
+    contracts: Contract<any> | [Contract<any>]
+  ): Promise<void>;
 }
 
 interface ContractContextDefinition extends Mocha.IContextDefinition {

--- a/migrations/2_deploy_contracts.ts
+++ b/migrations/2_deploy_contracts.ts
@@ -1,6 +1,10 @@
+const AddressSet = artifacts.require('./AddressSet.sol');
 const SignHash = artifacts.require('./SignHash.sol');
 
 async function deploy(deployer: Deployer): Promise<void> {
+  await deployer.deploy(AddressSet);
+  await deployer.link(AddressSet, SignHash);
+
   await deployer.deploy(SignHash);
 }
 

--- a/test/TestAddressSet.sol
+++ b/test/TestAddressSet.sol
@@ -62,6 +62,36 @@ contract TestAddressSet {
         Assert.equal(set.list[2], address3, "Third element should match");
     }
 
+    function testRemove() public {
+        set.add(address1);
+        set.remove(address1);
+
+        Assert.equal(set.list.length, 0, "List should be empty");
+        Assert.equal(set.index[address1], 0, "Index should not contain the address");
+    }
+
+    function testRemoveFirst() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+        set.remove(address1);
+
+        Assert.equal(set.list.length, 2, "List should have a two elements");
+        Assert.equal(set.list[0], address3, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+    }
+
+    function testRemoveLast() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+        set.remove(address3);
+
+        Assert.equal(set.list.length, 2, "List should have a two elements");
+        Assert.equal(set.list[0], address1, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+    }
+
     function testClear() public {
         set.add(address1);
         set.add(address2);

--- a/test/TestAddressSet.sol
+++ b/test/TestAddressSet.sol
@@ -8,32 +8,30 @@ import "../contracts/AddressSet.sol";
 contract TestAddressSet {
     using AddressSet for AddressSet.Data;
 
-    address address1 = address(1);
-    address address2 = address(2);
-    address address3 = address(3);
+    address private address1 = address(1);
+    address private address2 = address(2);
+    address private address3 = address(3);
 
-    AddressSet.Data set;
+    AddressSet.Data private set;
 
     function beforeEach() public {
         set.clear();
     }
 
     function testSetInitiallyEmpty() public {
-        Assert.equal(set.list.length, 0, "List should be empty");
+        assertEmpty(set);
     }
 
     function testAdd() public {
         set.add(address1);
 
-        Assert.equal(set.list.length, 1, "List should have a single element");
-        Assert.equal(set.list[0], address1, "First element should match");
+        assertElement(set, address1);
     }
 
     function testAddDuplicate() public {
         set.add(address1);
 
-        Assert.equal(set.list.length, 1, "List should have a single element");
-        Assert.equal(set.list[0], address1, "First element should match");
+        assertElement(set, address1);
     }
 
     function testAddMultiple() public {
@@ -41,13 +39,12 @@ contract TestAddressSet {
         set.add(address2);
         set.add(address3);
 
-        Assert.equal(set.list.length, 3, "List should have a single element");
-        Assert.equal(set.list[0], address1, "First element should match");
-        Assert.equal(set.list[1], address2, "Second element should match");
-        Assert.equal(set.list[2], address3, "Third element should match");
+        assertElements(set, address1, address2, address3);
     }
 
     function testAddMultipleWithDuplicates() public {
+        // keeps order of elements
+
         set.add(address1);
         set.add(address2);
         set.add(address3);
@@ -56,50 +53,119 @@ contract TestAddressSet {
         set.add(address3);
         set.add(address2);
 
-        Assert.equal(set.list.length, 3, "List should have a single element");
-        Assert.equal(set.list[0], address1, "First element should match");
-        Assert.equal(set.list[1], address2, "Second element should match");
-        Assert.equal(set.list[2], address3, "Third element should match");
+        assertElements(set, address1, address2, address3);
     }
 
     function testRemove() public {
         set.add(address1);
         set.remove(address1);
 
-        Assert.equal(set.list.length, 0, "List should be empty");
-        Assert.equal(set.index[address1], 0, "Index should not contain the address");
+        assertEmpty(set);
     }
 
     function testRemoveFirst() public {
+        // keeps order of elements
+
         set.add(address1);
         set.add(address2);
         set.add(address3);
         set.remove(address1);
 
-        Assert.equal(set.list.length, 2, "List should have a two elements");
-        Assert.equal(set.list[0], address3, "First element should match");
-        Assert.equal(set.list[1], address2, "Second element should match");
+        assertElements(set, address2, address3);
     }
 
     function testRemoveLast() public {
+        // keeps order of elements
+
         set.add(address1);
         set.add(address2);
         set.add(address3);
         set.remove(address3);
 
-        Assert.equal(set.list.length, 2, "List should have a two elements");
-        Assert.equal(set.list[0], address1, "First element should match");
-        Assert.equal(set.list[1], address2, "Second element should match");
+        assertElements(set, address1, address2);
+    }
+
+    function testRemoveAll() public {
+        // keeps order of elements
+
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+        set.remove(address3);
+        set.remove(address1);
+        set.remove(address2);
+
+        assertEmpty(set);
     }
 
     function testClear() public {
         set.add(address1);
         set.add(address2);
-
         set.clear();
 
-        Assert.equal(set.list.length, 0, "List should be empty");
-        Assert.equal(set.index[address1], 0, "Index should not contain the first address");
-        Assert.equal(set.index[address2], 0, "Index should not contain the second address");
+        assertEmpty(set);
+    }
+
+    function assertEmpty(AddressSet.Data storage actual) private constant {
+        Assert.equal(actual.list.length, 0, "List should be empty");
+        Assert.equal(actual.index[address1], 0, "Address1 should not exist in index");
+        Assert.equal(actual.index[address2], 0, "Address2 should not exist in index");
+        Assert.equal(actual.index[address3], 0, "Address3 should not exist in index");
+    }
+
+    function assertElement(
+        AddressSet.Data storage actual,
+        address expected1
+    )
+        private
+        constant
+    {
+        address[] memory expected = new address[](1);
+        expected[0] = expected1;
+        assertElements(actual, expected);
+    }
+
+    function assertElements(
+        AddressSet.Data storage actual,
+        address expected1,
+        address expected2
+    )
+        private
+        constant
+    {
+        address[] memory expected = new address[](2);
+        expected[0] = expected1;
+        expected[1] = expected2;
+        assertElements(actual, expected);
+    }
+
+    function assertElements(
+        AddressSet.Data storage actual,
+        address expected1,
+        address expected2,
+        address expected3
+    )
+        private
+        constant
+    {
+        address[] memory expected = new address[](3);
+        expected[0] = expected1;
+        expected[1] = expected2;
+        expected[2] = expected3;
+        assertElements(actual, expected);
+    }
+
+    function assertElements(
+        AddressSet.Data storage actual,
+        address[] memory expected
+    )
+        private
+        constant
+    {
+        Assert.equal(actual.list.length, expected.length, "Should contain the same number of elements");
+        for (uint256 i = 0; i < expected.length; i++) {
+            Assert.equal(actual.list[i], expected[i], "Addresses should match");
+            Assert.notEqual(actual.index[expected[i]], 0, "Address should exist in index");
+        }
     }
 }

--- a/test/TestAddressSet.sol
+++ b/test/TestAddressSet.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.4.0;
+
+import "truffle/Assert.sol";
+
+import "../contracts/AddressSet.sol";
+
+
+contract TestAddressSet {
+    using AddressSet for AddressSet.Data;
+
+    address address1 = address(1);
+    address address2 = address(2);
+    address address3 = address(3);
+
+    AddressSet.Data set;
+
+    function beforeEach() public {
+        set.clear();
+    }
+
+    function testSetInitiallyEmpty() public {
+        Assert.equal(set.list.length, 0, "List should be empty");
+    }
+
+    function testAdd() public {
+        set.add(address1);
+
+        Assert.equal(set.list.length, 1, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+    }
+
+    function testAddDuplicate() public {
+        set.add(address1);
+
+        Assert.equal(set.list.length, 1, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+    }
+
+    function testAddMultiple() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+
+        Assert.equal(set.list.length, 3, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+        Assert.equal(set.list[2], address3, "Third element should match");
+    }
+
+    function testAddMultipleWithDuplicates() public {
+        set.add(address1);
+        set.add(address2);
+        set.add(address3);
+        set.add(address2);
+        set.add(address1);
+        set.add(address3);
+        set.add(address2);
+
+        Assert.equal(set.list.length, 3, "List should have a single element");
+        Assert.equal(set.list[0], address1, "First element should match");
+        Assert.equal(set.list[1], address2, "Second element should match");
+        Assert.equal(set.list[2], address3, "Third element should match");
+    }
+
+    function testClear() public {
+        set.add(address1);
+        set.add(address2);
+
+        set.clear();
+
+        Assert.equal(set.list.length, 0, "List should be empty");
+        Assert.equal(set.index[address1], 0, "Index should not contain the first address");
+        Assert.equal(set.index[address2], 0, "Index should not contain the second address");
+    }
+}

--- a/test/signhash.ts
+++ b/test/signhash.ts
@@ -40,6 +40,14 @@ contract('SignHash', accounts => {
       assert.deepEqual(signers.sort(), accounts.sort());
     });
 
+    it('should add signer only once', async () => {
+      await instance.sign(hash);
+      await instance.sign(hash);
+
+      const signers = await instance.getSigners(hash);
+      assert.deepEqual(signers, [defaultAccount]);
+    });
+
     it('should emit Signed event', async () => {
       const trans = await instance.sign(hash);
       const log = findLastLog(trans, 'Signed');


### PR DESCRIPTION
This PR depends on changes introduced in #12.
Merge only after merging #12.

A lot of code was introduced to maintain chronological order of signers after revocation. I tried to make it as straightforward and cheap in execution as possible. 

Closes #8