### PR TITLE
TestRPC with contracts deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 
 # tsc generated files
 *.map
-*.js
+truffle.js
+migrations/*.js
+test/*.js
 !truffle-config.js
 
 # Logs
@@ -67,4 +69,3 @@ typings/
 
 # dotenv environment variables file
 .env
-

--- a/build/contracts/AddressSet.json
+++ b/build/contracts/AddressSet.json
@@ -1,0 +1,4501 @@
+{
+  "contractName": "AddressSet",
+  "abi": [],
+  "bytecode":
+    "0x60606040523415600e57600080fd5b603580601b6000396000f3006060604052600080fd00a165627a7a72305820f65bb075e8bd8c3992bb04917cbf3b870d5dc6e91ffea7d26f2a1f58072a1d8a0029",
+  "deployedBytecode":
+    "0x6060604052600080fd00a165627a7a72305820f65bb075e8bd8c3992bb04917cbf3b870d5dc6e91ffea7d26f2a1f58072a1d8a0029",
+  "sourceMap": "26:2889:0:-;;;;;;;;;;;;;;;;;",
+  "deployedSourceMap": "26:2889:0:-;;;;;",
+  "source":
+    "pragma solidity 0.4.18;\n\n\nlibrary AddressSet {\n\n    //--- Definitions\n    struct Link {\n        address previous;\n        address next;\n    }\n\n    struct Data {\n        address head;\n        address tail;\n        uint256 count;\n        mapping (address => Link) links;\n    }\n\n    //--- Public mutable functions\n    function add(\n        Data storage self,\n        address element\n    )\n        internal\n        returns (bool)\n    {\n        require(element != address(0));\n\n        if (self.head == address(0)) { // empty list\n            self.head = element;\n        } else if (!contains(self, element)) { // not existing\n            self.links[self.tail].next = element;\n            self.links[element].previous = self.tail;\n        } else { // duplicate\n            return false;\n        }\n\n        self.tail = element;\n        safeIncrement(self);\n\n        return true;\n    }\n\n    function remove(\n        Data storage self,\n        address element\n    )\n        internal\n        returns (bool)\n    {\n        require(element != address(0));\n\n        Link storage link = self.links[element];\n\n        if (link.previous != address(0)) { // middle or tail\n            self.links[link.previous].next = link.next;\n        } else if (element == self.head) { // head\n            self.head = link.next;\n        } else { // not existing\n            return false;\n        }\n\n        if (link.next != address(0)) {\n            self.links[link.next].previous = link.previous;\n        } else {\n            self.tail = link.previous;\n        }\n\n        safeDecrement(self);\n        delete self.links[element];\n\n        return true;\n    }\n\n    function clear(Data storage self) internal {\n        address current = self.head;\n\n        while (current != address(0)) {\n            address next = self.links[current].next;\n            delete self.links[current];\n            current = next;\n        }\n\n        delete self.head;\n        delete self.tail;\n        delete self.count;\n    }\n\n    //--- Public view functions\n    function getNext(\n        Data storage self,\n        address current\n    )\n        internal\n        view\n        returns (address)\n    {\n        return self.links[current].next;\n    }\n\n    function getPrevious(\n        Data storage self,\n        address current\n    )\n        internal\n        view\n        returns (address)\n    {\n        return self.links[current].previous;\n    }\n\n    function contains(\n        Data storage self,\n        address element\n    )\n        internal\n        view\n        returns (bool)\n    {\n        return element == self.head ||\n            self.links[element].previous != address(0);\n    }\n\n    //--- Private mutable functions\n    function safeIncrement(Data storage self) private {\n        assert(self.count + 1 > self.count);\n        self.count++;\n    }\n\n    function safeDecrement(Data storage self) private {\n        assert(self.count > 0);\n        self.count--;\n    }\n}\n\n",
+  "sourcePath":
+    "/home/biern/projects/signhash/signhash-contracts/contracts/AddressSet.sol",
+  "ast": {
+    "attributes": {
+      "absolutePath":
+        "/home/biern/projects/signhash/signhash-contracts/contracts/AddressSet.sol",
+      "exportedSymbols": {
+        "AddressSet": [335]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": ["solidity", "0.4", ".18", ".18"]
+        },
+        "id": 1,
+        "name": "PragmaDirective",
+        "src": "0:23:0"
+      },
+      {
+        "attributes": {
+          "baseContracts": [null],
+          "contractDependencies": [null],
+          "contractKind": "library",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [335],
+          "name": "AddressSet",
+          "scope": 336
+        },
+        "children": [
+          {
+            "attributes": {
+              "canonicalName": "AddressSet.Link",
+              "name": "Link",
+              "scope": 335,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "previous",
+                  "scope": 6,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type": "address",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 2,
+                    "name": "ElementaryTypeName",
+                    "src": "96:7:0"
+                  }
+                ],
+                "id": 3,
+                "name": "VariableDeclaration",
+                "src": "96:16:0"
+              },
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "next",
+                  "scope": 6,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type": "address",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 4,
+                    "name": "ElementaryTypeName",
+                    "src": "122:7:0"
+                  }
+                ],
+                "id": 5,
+                "name": "VariableDeclaration",
+                "src": "122:12:0"
+              }
+            ],
+            "id": 6,
+            "name": "StructDefinition",
+            "src": "74:67:0"
+          },
+          {
+            "attributes": {
+              "canonicalName": "AddressSet.Data",
+              "name": "Data",
+              "scope": 335,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "head",
+                  "scope": 17,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type": "address",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 7,
+                    "name": "ElementaryTypeName",
+                    "src": "169:7:0"
+                  }
+                ],
+                "id": 8,
+                "name": "VariableDeclaration",
+                "src": "169:12:0"
+              },
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "tail",
+                  "scope": 17,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type": "address",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 9,
+                    "name": "ElementaryTypeName",
+                    "src": "191:7:0"
+                  }
+                ],
+                "id": 10,
+                "name": "VariableDeclaration",
+                "src": "191:12:0"
+              },
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "count",
+                  "scope": 17,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type": "uint256",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "uint256",
+                      "type": "uint256"
+                    },
+                    "id": 11,
+                    "name": "ElementaryTypeName",
+                    "src": "213:7:0"
+                  }
+                ],
+                "id": 12,
+                "name": "VariableDeclaration",
+                "src": "213:13:0"
+              },
+              {
+                "attributes": {
+                  "constant": false,
+                  "name": "links",
+                  "scope": 17,
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "type":
+                    "mapping(address => struct AddressSet.Link storage ref)",
+                  "value": null,
+                  "visibility": "internal"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "type":
+                        "mapping(address => struct AddressSet.Link storage ref)"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 13,
+                        "name": "ElementaryTypeName",
+                        "src": "245:7:0"
+                      },
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Link",
+                          "referencedDeclaration": 6,
+                          "type": "struct AddressSet.Link storage pointer"
+                        },
+                        "id": 14,
+                        "name": "UserDefinedTypeName",
+                        "src": "256:4:0"
+                      }
+                    ],
+                    "id": 15,
+                    "name": "Mapping",
+                    "src": "236:25:0"
+                  }
+                ],
+                "id": 16,
+                "name": "VariableDeclaration",
+                "src": "236:31:0"
+              }
+            ],
+            "id": 17,
+            "name": "StructDefinition",
+            "src": "147:127:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "add",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 91,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 18,
+                        "name": "UserDefinedTypeName",
+                        "src": "337:4:0"
+                      }
+                    ],
+                    "id": 19,
+                    "name": "VariableDeclaration",
+                    "src": "337:17:0"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "element",
+                      "scope": 91,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 20,
+                        "name": "ElementaryTypeName",
+                        "src": "364:7:0"
+                      }
+                    ],
+                    "id": 21,
+                    "name": "VariableDeclaration",
+                    "src": "364:15:0"
+                  }
+                ],
+                "id": 22,
+                "name": "ParameterList",
+                "src": "327:58:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 91,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bool",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bool",
+                          "type": "bool"
+                        },
+                        "id": 23,
+                        "name": "ElementaryTypeName",
+                        "src": "420:4:0"
+                      }
+                    ],
+                    "id": 24,
+                    "name": "VariableDeclaration",
+                    "src": "420:4:0"
+                  }
+                ],
+                "id": 25,
+                "name": "ParameterList",
+                "src": "419:6:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 26,
+                            "name": "Identifier",
+                            "src": "440:7:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 21,
+                                  "type": "address",
+                                  "value": "element"
+                                },
+                                "id": 27,
+                                "name": "Identifier",
+                                "src": "448:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "address",
+                                  "type_conversion": true
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(address)",
+                                      "value": "address"
+                                    },
+                                    "id": 28,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "459:7:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 29,
+                                    "name": "Literal",
+                                    "src": "467:1:0"
+                                  }
+                                ],
+                                "id": 30,
+                                "name": "FunctionCall",
+                                "src": "459:10:0"
+                              }
+                            ],
+                            "id": 31,
+                            "name": "BinaryOperation",
+                            "src": "448:21:0"
+                          }
+                        ],
+                        "id": 32,
+                        "name": "FunctionCall",
+                        "src": "440:30:0"
+                      }
+                    ],
+                    "id": 33,
+                    "name": "ExpressionStatement",
+                    "src": "440:30:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "==",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "head",
+                              "referencedDeclaration": 8,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 19,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 34,
+                                "name": "Identifier",
+                                "src": "485:4:0"
+                              }
+                            ],
+                            "id": 35,
+                            "name": "MemberAccess",
+                            "src": "485:9:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "isStructConstructorCall": false,
+                              "lValueRequested": false,
+                              "names": [null],
+                              "type": "address",
+                              "type_conversion": true
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": [
+                                    {
+                                      "typeIdentifier": "t_rational_0_by_1",
+                                      "typeString": "int_const 0"
+                                    }
+                                  ],
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "type": "type(address)",
+                                  "value": "address"
+                                },
+                                "id": 36,
+                                "name": "ElementaryTypeNameExpression",
+                                "src": "498:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 37,
+                                "name": "Literal",
+                                "src": "506:1:0"
+                              }
+                            ],
+                            "id": 38,
+                            "name": "FunctionCall",
+                            "src": "498:10:0"
+                          }
+                        ],
+                        "id": 39,
+                        "name": "BinaryOperation",
+                        "src": "485:23:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "=",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": true,
+                                      "member_name": "head",
+                                      "referencedDeclaration": 8,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 19,
+                                          "type":
+                                            "struct AddressSet.Data storage pointer",
+                                          "value": "self"
+                                        },
+                                        "id": 40,
+                                        "name": "Identifier",
+                                        "src": "538:4:0"
+                                      }
+                                    ],
+                                    "id": 42,
+                                    "name": "MemberAccess",
+                                    "src": "538:9:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 21,
+                                      "type": "address",
+                                      "value": "element"
+                                    },
+                                    "id": 43,
+                                    "name": "Identifier",
+                                    "src": "550:7:0"
+                                  }
+                                ],
+                                "id": 44,
+                                "name": "Assignment",
+                                "src": "538:19:0"
+                              }
+                            ],
+                            "id": 45,
+                            "name": "ExpressionStatement",
+                            "src": "538:19:0"
+                          }
+                        ],
+                        "id": 46,
+                        "name": "Block",
+                        "src": "510:58:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!",
+                              "prefix": true,
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "bool",
+                                  "type_conversion": false
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier":
+                                            "t_struct$_Data_$17_storage_ptr",
+                                          "typeString":
+                                            "struct AddressSet.Data storage pointer"
+                                        },
+                                        {
+                                          "typeIdentifier": "t_address",
+                                          "typeString": "address"
+                                        }
+                                      ],
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 295,
+                                      "type":
+                                        "function (struct AddressSet.Data storage pointer,address) view returns (bool)",
+                                      "value": "contains"
+                                    },
+                                    "id": 47,
+                                    "name": "Identifier",
+                                    "src": "579:8:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 19,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 48,
+                                    "name": "Identifier",
+                                    "src": "588:4:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 21,
+                                      "type": "address",
+                                      "value": "element"
+                                    },
+                                    "id": 49,
+                                    "name": "Identifier",
+                                    "src": "594:7:0"
+                                  }
+                                ],
+                                "id": 50,
+                                "name": "FunctionCall",
+                                "src": "579:23:0"
+                              }
+                            ],
+                            "id": 51,
+                            "name": "UnaryOperation",
+                            "src": "578:24:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "=",
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": true,
+                                          "member_name": "next",
+                                          "referencedDeclaration": 5,
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "type":
+                                                "struct AddressSet.Link storage ref"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "links",
+                                                  "referencedDeclaration": 16,
+                                                  "type":
+                                                    "mapping(address => struct AddressSet.Link storage ref)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 19,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "self"
+                                                    },
+                                                    "id": 52,
+                                                    "name": "Identifier",
+                                                    "src": "634:4:0"
+                                                  }
+                                                ],
+                                                "id": 56,
+                                                "name": "MemberAccess",
+                                                "src": "634:10:0"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "tail",
+                                                  "referencedDeclaration": 10,
+                                                  "type": "address"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 19,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "self"
+                                                    },
+                                                    "id": 54,
+                                                    "name": "Identifier",
+                                                    "src": "645:4:0"
+                                                  }
+                                                ],
+                                                "id": 55,
+                                                "name": "MemberAccess",
+                                                "src": "645:9:0"
+                                              }
+                                            ],
+                                            "id": 57,
+                                            "name": "IndexAccess",
+                                            "src": "634:21:0"
+                                          }
+                                        ],
+                                        "id": 58,
+                                        "name": "MemberAccess",
+                                        "src": "634:26:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 21,
+                                          "type": "address",
+                                          "value": "element"
+                                        },
+                                        "id": 59,
+                                        "name": "Identifier",
+                                        "src": "663:7:0"
+                                      }
+                                    ],
+                                    "id": 60,
+                                    "name": "Assignment",
+                                    "src": "634:36:0"
+                                  }
+                                ],
+                                "id": 61,
+                                "name": "ExpressionStatement",
+                                "src": "634:36:0"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "=",
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": true,
+                                          "member_name": "previous",
+                                          "referencedDeclaration": 3,
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "type":
+                                                "struct AddressSet.Link storage ref"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "links",
+                                                  "referencedDeclaration": 16,
+                                                  "type":
+                                                    "mapping(address => struct AddressSet.Link storage ref)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 19,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "self"
+                                                    },
+                                                    "id": 62,
+                                                    "name": "Identifier",
+                                                    "src": "684:4:0"
+                                                  }
+                                                ],
+                                                "id": 65,
+                                                "name": "MemberAccess",
+                                                "src": "684:10:0"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 21,
+                                                  "type": "address",
+                                                  "value": "element"
+                                                },
+                                                "id": 64,
+                                                "name": "Identifier",
+                                                "src": "695:7:0"
+                                              }
+                                            ],
+                                            "id": 66,
+                                            "name": "IndexAccess",
+                                            "src": "684:19:0"
+                                          }
+                                        ],
+                                        "id": 67,
+                                        "name": "MemberAccess",
+                                        "src": "684:28:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "member_name": "tail",
+                                          "referencedDeclaration": 10,
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 19,
+                                              "type":
+                                                "struct AddressSet.Data storage pointer",
+                                              "value": "self"
+                                            },
+                                            "id": 68,
+                                            "name": "Identifier",
+                                            "src": "715:4:0"
+                                          }
+                                        ],
+                                        "id": 69,
+                                        "name": "MemberAccess",
+                                        "src": "715:9:0"
+                                      }
+                                    ],
+                                    "id": 70,
+                                    "name": "Assignment",
+                                    "src": "684:40:0"
+                                  }
+                                ],
+                                "id": 71,
+                                "name": "ExpressionStatement",
+                                "src": "684:40:0"
+                              }
+                            ],
+                            "id": 72,
+                            "name": "Block",
+                            "src": "604:131:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "functionReturnParameters": 25
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "66616c7365",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "bool",
+                                      "type": "bool",
+                                      "value": "false"
+                                    },
+                                    "id": 73,
+                                    "name": "Literal",
+                                    "src": "775:5:0"
+                                  }
+                                ],
+                                "id": 74,
+                                "name": "Return",
+                                "src": "768:12:0"
+                              }
+                            ],
+                            "id": 75,
+                            "name": "Block",
+                            "src": "741:50:0"
+                          }
+                        ],
+                        "id": 76,
+                        "name": "IfStatement",
+                        "src": "574:217:0"
+                      }
+                    ],
+                    "id": 77,
+                    "name": "IfStatement",
+                    "src": "481:310:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "tail",
+                              "referencedDeclaration": 10,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 19,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 78,
+                                "name": "Identifier",
+                                "src": "801:4:0"
+                              }
+                            ],
+                            "id": 80,
+                            "name": "MemberAccess",
+                            "src": "801:9:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 21,
+                              "type": "address",
+                              "value": "element"
+                            },
+                            "id": 81,
+                            "name": "Identifier",
+                            "src": "813:7:0"
+                          }
+                        ],
+                        "id": 82,
+                        "name": "Assignment",
+                        "src": "801:19:0"
+                      }
+                    ],
+                    "id": 83,
+                    "name": "ExpressionStatement",
+                    "src": "801:19:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier":
+                                    "t_struct$_Data_$17_storage_ptr",
+                                  "typeString":
+                                    "struct AddressSet.Data storage pointer"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 316,
+                              "type":
+                                "function (struct AddressSet.Data storage pointer)",
+                              "value": "safeIncrement"
+                            },
+                            "id": 84,
+                            "name": "Identifier",
+                            "src": "830:13:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 19,
+                              "type": "struct AddressSet.Data storage pointer",
+                              "value": "self"
+                            },
+                            "id": 85,
+                            "name": "Identifier",
+                            "src": "844:4:0"
+                          }
+                        ],
+                        "id": 86,
+                        "name": "FunctionCall",
+                        "src": "830:19:0"
+                      }
+                    ],
+                    "id": 87,
+                    "name": "ExpressionStatement",
+                    "src": "830:19:0"
+                  },
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 25
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "hexvalue": "74727565",
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "subdenomination": null,
+                          "token": "bool",
+                          "type": "bool",
+                          "value": "true"
+                        },
+                        "id": 88,
+                        "name": "Literal",
+                        "src": "867:4:0"
+                      }
+                    ],
+                    "id": 89,
+                    "name": "Return",
+                    "src": "860:11:0"
+                  }
+                ],
+                "id": 90,
+                "name": "Block",
+                "src": "430:448:0"
+              }
+            ],
+            "id": 91,
+            "name": "FunctionDefinition",
+            "src": "315:563:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "remove",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 190,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 92,
+                        "name": "UserDefinedTypeName",
+                        "src": "909:4:0"
+                      }
+                    ],
+                    "id": 93,
+                    "name": "VariableDeclaration",
+                    "src": "909:17:0"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "element",
+                      "scope": 190,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 94,
+                        "name": "ElementaryTypeName",
+                        "src": "936:7:0"
+                      }
+                    ],
+                    "id": 95,
+                    "name": "VariableDeclaration",
+                    "src": "936:15:0"
+                  }
+                ],
+                "id": 96,
+                "name": "ParameterList",
+                "src": "899:58:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 190,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bool",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bool",
+                          "type": "bool"
+                        },
+                        "id": 97,
+                        "name": "ElementaryTypeName",
+                        "src": "992:4:0"
+                      }
+                    ],
+                    "id": 98,
+                    "name": "VariableDeclaration",
+                    "src": "992:4:0"
+                  }
+                ],
+                "id": 99,
+                "name": "ParameterList",
+                "src": "991:6:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 100,
+                            "name": "Identifier",
+                            "src": "1012:7:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 95,
+                                  "type": "address",
+                                  "value": "element"
+                                },
+                                "id": 101,
+                                "name": "Identifier",
+                                "src": "1020:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "address",
+                                  "type_conversion": true
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(address)",
+                                      "value": "address"
+                                    },
+                                    "id": 102,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "1031:7:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 103,
+                                    "name": "Literal",
+                                    "src": "1039:1:0"
+                                  }
+                                ],
+                                "id": 104,
+                                "name": "FunctionCall",
+                                "src": "1031:10:0"
+                              }
+                            ],
+                            "id": 105,
+                            "name": "BinaryOperation",
+                            "src": "1020:21:0"
+                          }
+                        ],
+                        "id": 106,
+                        "name": "FunctionCall",
+                        "src": "1012:30:0"
+                      }
+                    ],
+                    "id": 107,
+                    "name": "ExpressionStatement",
+                    "src": "1012:30:0"
+                  },
+                  {
+                    "attributes": {
+                      "assignments": [109]
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "link",
+                          "scope": 190,
+                          "stateVariable": false,
+                          "storageLocation": "storage",
+                          "type": "struct AddressSet.Link storage pointer",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "contractScope": null,
+                              "name": "Link",
+                              "referencedDeclaration": 6,
+                              "type": "struct AddressSet.Link storage pointer"
+                            },
+                            "id": 108,
+                            "name": "UserDefinedTypeName",
+                            "src": "1053:4:0"
+                          }
+                        ],
+                        "id": 109,
+                        "name": "VariableDeclaration",
+                        "src": "1053:17:0"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "struct AddressSet.Link storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "links",
+                              "referencedDeclaration": 16,
+                              "type":
+                                "mapping(address => struct AddressSet.Link storage ref)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 93,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 110,
+                                "name": "Identifier",
+                                "src": "1073:4:0"
+                              }
+                            ],
+                            "id": 111,
+                            "name": "MemberAccess",
+                            "src": "1073:10:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 95,
+                              "type": "address",
+                              "value": "element"
+                            },
+                            "id": 112,
+                            "name": "Identifier",
+                            "src": "1084:7:0"
+                          }
+                        ],
+                        "id": 113,
+                        "name": "IndexAccess",
+                        "src": "1073:19:0"
+                      }
+                    ],
+                    "id": 114,
+                    "name": "VariableDeclarationStatement",
+                    "src": "1053:39:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "!=",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "previous",
+                              "referencedDeclaration": 3,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 109,
+                                  "type":
+                                    "struct AddressSet.Link storage pointer",
+                                  "value": "link"
+                                },
+                                "id": 115,
+                                "name": "Identifier",
+                                "src": "1107:4:0"
+                              }
+                            ],
+                            "id": 116,
+                            "name": "MemberAccess",
+                            "src": "1107:13:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "isStructConstructorCall": false,
+                              "lValueRequested": false,
+                              "names": [null],
+                              "type": "address",
+                              "type_conversion": true
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": [
+                                    {
+                                      "typeIdentifier": "t_rational_0_by_1",
+                                      "typeString": "int_const 0"
+                                    }
+                                  ],
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "type": "type(address)",
+                                  "value": "address"
+                                },
+                                "id": 117,
+                                "name": "ElementaryTypeNameExpression",
+                                "src": "1124:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 118,
+                                "name": "Literal",
+                                "src": "1132:1:0"
+                              }
+                            ],
+                            "id": 119,
+                            "name": "FunctionCall",
+                            "src": "1124:10:0"
+                          }
+                        ],
+                        "id": 120,
+                        "name": "BinaryOperation",
+                        "src": "1107:27:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "=",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": true,
+                                      "member_name": "next",
+                                      "referencedDeclaration": 5,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "type":
+                                            "struct AddressSet.Link storage ref"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "member_name": "links",
+                                              "referencedDeclaration": 16,
+                                              "type":
+                                                "mapping(address => struct AddressSet.Link storage ref)"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 93,
+                                                  "type":
+                                                    "struct AddressSet.Data storage pointer",
+                                                  "value": "self"
+                                                },
+                                                "id": 121,
+                                                "name": "Identifier",
+                                                "src": "1168:4:0"
+                                              }
+                                            ],
+                                            "id": 125,
+                                            "name": "MemberAccess",
+                                            "src": "1168:10:0"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "member_name": "previous",
+                                              "referencedDeclaration": 3,
+                                              "type": "address"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 109,
+                                                  "type":
+                                                    "struct AddressSet.Link storage pointer",
+                                                  "value": "link"
+                                                },
+                                                "id": 123,
+                                                "name": "Identifier",
+                                                "src": "1179:4:0"
+                                              }
+                                            ],
+                                            "id": 124,
+                                            "name": "MemberAccess",
+                                            "src": "1179:13:0"
+                                          }
+                                        ],
+                                        "id": 126,
+                                        "name": "IndexAccess",
+                                        "src": "1168:25:0"
+                                      }
+                                    ],
+                                    "id": 127,
+                                    "name": "MemberAccess",
+                                    "src": "1168:30:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "next",
+                                      "referencedDeclaration": 5,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 109,
+                                          "type":
+                                            "struct AddressSet.Link storage pointer",
+                                          "value": "link"
+                                        },
+                                        "id": 128,
+                                        "name": "Identifier",
+                                        "src": "1201:4:0"
+                                      }
+                                    ],
+                                    "id": 129,
+                                    "name": "MemberAccess",
+                                    "src": "1201:9:0"
+                                  }
+                                ],
+                                "id": 130,
+                                "name": "Assignment",
+                                "src": "1168:42:0"
+                              }
+                            ],
+                            "id": 131,
+                            "name": "ExpressionStatement",
+                            "src": "1168:42:0"
+                          }
+                        ],
+                        "id": 132,
+                        "name": "Block",
+                        "src": "1136:85:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "==",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 95,
+                                  "type": "address",
+                                  "value": "element"
+                                },
+                                "id": 133,
+                                "name": "Identifier",
+                                "src": "1231:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "head",
+                                  "referencedDeclaration": 8,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 93,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 134,
+                                    "name": "Identifier",
+                                    "src": "1242:4:0"
+                                  }
+                                ],
+                                "id": 135,
+                                "name": "MemberAccess",
+                                "src": "1242:9:0"
+                              }
+                            ],
+                            "id": 136,
+                            "name": "BinaryOperation",
+                            "src": "1231:20:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "=",
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": true,
+                                          "member_name": "head",
+                                          "referencedDeclaration": 8,
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 93,
+                                              "type":
+                                                "struct AddressSet.Data storage pointer",
+                                              "value": "self"
+                                            },
+                                            "id": 137,
+                                            "name": "Identifier",
+                                            "src": "1275:4:0"
+                                          }
+                                        ],
+                                        "id": 139,
+                                        "name": "MemberAccess",
+                                        "src": "1275:9:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "member_name": "next",
+                                          "referencedDeclaration": 5,
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 109,
+                                              "type":
+                                                "struct AddressSet.Link storage pointer",
+                                              "value": "link"
+                                            },
+                                            "id": 140,
+                                            "name": "Identifier",
+                                            "src": "1287:4:0"
+                                          }
+                                        ],
+                                        "id": 141,
+                                        "name": "MemberAccess",
+                                        "src": "1287:9:0"
+                                      }
+                                    ],
+                                    "id": 142,
+                                    "name": "Assignment",
+                                    "src": "1275:21:0"
+                                  }
+                                ],
+                                "id": 143,
+                                "name": "ExpressionStatement",
+                                "src": "1275:21:0"
+                              }
+                            ],
+                            "id": 144,
+                            "name": "Block",
+                            "src": "1253:54:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "functionReturnParameters": 99
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "66616c7365",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "bool",
+                                      "type": "bool",
+                                      "value": "false"
+                                    },
+                                    "id": 145,
+                                    "name": "Literal",
+                                    "src": "1350:5:0"
+                                  }
+                                ],
+                                "id": 146,
+                                "name": "Return",
+                                "src": "1343:12:0"
+                              }
+                            ],
+                            "id": 147,
+                            "name": "Block",
+                            "src": "1313:53:0"
+                          }
+                        ],
+                        "id": 148,
+                        "name": "IfStatement",
+                        "src": "1227:139:0"
+                      }
+                    ],
+                    "id": 149,
+                    "name": "IfStatement",
+                    "src": "1103:263:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "!=",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "next",
+                              "referencedDeclaration": 5,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 109,
+                                  "type":
+                                    "struct AddressSet.Link storage pointer",
+                                  "value": "link"
+                                },
+                                "id": 150,
+                                "name": "Identifier",
+                                "src": "1380:4:0"
+                              }
+                            ],
+                            "id": 151,
+                            "name": "MemberAccess",
+                            "src": "1380:9:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "isStructConstructorCall": false,
+                              "lValueRequested": false,
+                              "names": [null],
+                              "type": "address",
+                              "type_conversion": true
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": [
+                                    {
+                                      "typeIdentifier": "t_rational_0_by_1",
+                                      "typeString": "int_const 0"
+                                    }
+                                  ],
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "type": "type(address)",
+                                  "value": "address"
+                                },
+                                "id": 152,
+                                "name": "ElementaryTypeNameExpression",
+                                "src": "1393:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 153,
+                                "name": "Literal",
+                                "src": "1401:1:0"
+                              }
+                            ],
+                            "id": 154,
+                            "name": "FunctionCall",
+                            "src": "1393:10:0"
+                          }
+                        ],
+                        "id": 155,
+                        "name": "BinaryOperation",
+                        "src": "1380:23:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "=",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": true,
+                                      "member_name": "previous",
+                                      "referencedDeclaration": 3,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "type":
+                                            "struct AddressSet.Link storage ref"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "member_name": "links",
+                                              "referencedDeclaration": 16,
+                                              "type":
+                                                "mapping(address => struct AddressSet.Link storage ref)"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 93,
+                                                  "type":
+                                                    "struct AddressSet.Data storage pointer",
+                                                  "value": "self"
+                                                },
+                                                "id": 156,
+                                                "name": "Identifier",
+                                                "src": "1419:4:0"
+                                              }
+                                            ],
+                                            "id": 160,
+                                            "name": "MemberAccess",
+                                            "src": "1419:10:0"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": false,
+                                              "member_name": "next",
+                                              "referencedDeclaration": 5,
+                                              "type": "address"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 109,
+                                                  "type":
+                                                    "struct AddressSet.Link storage pointer",
+                                                  "value": "link"
+                                                },
+                                                "id": 158,
+                                                "name": "Identifier",
+                                                "src": "1430:4:0"
+                                              }
+                                            ],
+                                            "id": 159,
+                                            "name": "MemberAccess",
+                                            "src": "1430:9:0"
+                                          }
+                                        ],
+                                        "id": 161,
+                                        "name": "IndexAccess",
+                                        "src": "1419:21:0"
+                                      }
+                                    ],
+                                    "id": 162,
+                                    "name": "MemberAccess",
+                                    "src": "1419:30:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "previous",
+                                      "referencedDeclaration": 3,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 109,
+                                          "type":
+                                            "struct AddressSet.Link storage pointer",
+                                          "value": "link"
+                                        },
+                                        "id": 163,
+                                        "name": "Identifier",
+                                        "src": "1452:4:0"
+                                      }
+                                    ],
+                                    "id": 164,
+                                    "name": "MemberAccess",
+                                    "src": "1452:13:0"
+                                  }
+                                ],
+                                "id": 165,
+                                "name": "Assignment",
+                                "src": "1419:46:0"
+                              }
+                            ],
+                            "id": 166,
+                            "name": "ExpressionStatement",
+                            "src": "1419:46:0"
+                          }
+                        ],
+                        "id": 167,
+                        "name": "Block",
+                        "src": "1405:71:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "=",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": true,
+                                      "member_name": "tail",
+                                      "referencedDeclaration": 10,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 93,
+                                          "type":
+                                            "struct AddressSet.Data storage pointer",
+                                          "value": "self"
+                                        },
+                                        "id": 168,
+                                        "name": "Identifier",
+                                        "src": "1496:4:0"
+                                      }
+                                    ],
+                                    "id": 170,
+                                    "name": "MemberAccess",
+                                    "src": "1496:9:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "previous",
+                                      "referencedDeclaration": 3,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 109,
+                                          "type":
+                                            "struct AddressSet.Link storage pointer",
+                                          "value": "link"
+                                        },
+                                        "id": 171,
+                                        "name": "Identifier",
+                                        "src": "1508:4:0"
+                                      }
+                                    ],
+                                    "id": 172,
+                                    "name": "MemberAccess",
+                                    "src": "1508:13:0"
+                                  }
+                                ],
+                                "id": 173,
+                                "name": "Assignment",
+                                "src": "1496:25:0"
+                              }
+                            ],
+                            "id": 174,
+                            "name": "ExpressionStatement",
+                            "src": "1496:25:0"
+                          }
+                        ],
+                        "id": 175,
+                        "name": "Block",
+                        "src": "1482:50:0"
+                      }
+                    ],
+                    "id": 176,
+                    "name": "IfStatement",
+                    "src": "1376:156:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier":
+                                    "t_struct$_Data_$17_storage_ptr",
+                                  "typeString":
+                                    "struct AddressSet.Data storage pointer"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 334,
+                              "type":
+                                "function (struct AddressSet.Data storage pointer)",
+                              "value": "safeDecrement"
+                            },
+                            "id": 177,
+                            "name": "Identifier",
+                            "src": "1542:13:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 93,
+                              "type": "struct AddressSet.Data storage pointer",
+                              "value": "self"
+                            },
+                            "id": 178,
+                            "name": "Identifier",
+                            "src": "1556:4:0"
+                          }
+                        ],
+                        "id": 179,
+                        "name": "FunctionCall",
+                        "src": "1542:19:0"
+                      }
+                    ],
+                    "id": 180,
+                    "name": "ExpressionStatement",
+                    "src": "1542:19:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "delete",
+                          "prefix": true,
+                          "type": "tuple()"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "type": "struct AddressSet.Link storage ref"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "links",
+                                  "referencedDeclaration": 16,
+                                  "type":
+                                    "mapping(address => struct AddressSet.Link storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 93,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 181,
+                                    "name": "Identifier",
+                                    "src": "1578:4:0"
+                                  }
+                                ],
+                                "id": 182,
+                                "name": "MemberAccess",
+                                "src": "1578:10:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 95,
+                                  "type": "address",
+                                  "value": "element"
+                                },
+                                "id": 183,
+                                "name": "Identifier",
+                                "src": "1589:7:0"
+                              }
+                            ],
+                            "id": 184,
+                            "name": "IndexAccess",
+                            "src": "1578:19:0"
+                          }
+                        ],
+                        "id": 185,
+                        "name": "UnaryOperation",
+                        "src": "1571:26:0"
+                      }
+                    ],
+                    "id": 186,
+                    "name": "ExpressionStatement",
+                    "src": "1571:26:0"
+                  },
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 99
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "hexvalue": "74727565",
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "subdenomination": null,
+                          "token": "bool",
+                          "type": "bool",
+                          "value": "true"
+                        },
+                        "id": 187,
+                        "name": "Literal",
+                        "src": "1615:4:0"
+                      }
+                    ],
+                    "id": 188,
+                    "name": "Return",
+                    "src": "1608:11:0"
+                  }
+                ],
+                "id": 189,
+                "name": "Block",
+                "src": "1002:624:0"
+              }
+            ],
+            "id": 190,
+            "name": "FunctionDefinition",
+            "src": "884:742:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "clear",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 238,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 191,
+                        "name": "UserDefinedTypeName",
+                        "src": "1647:4:0"
+                      }
+                    ],
+                    "id": 192,
+                    "name": "VariableDeclaration",
+                    "src": "1647:17:0"
+                  }
+                ],
+                "id": 193,
+                "name": "ParameterList",
+                "src": "1646:19:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 194,
+                "name": "ParameterList",
+                "src": "1675:0:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "assignments": [196]
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "current",
+                          "scope": 238,
+                          "stateVariable": false,
+                          "storageLocation": "default",
+                          "type": "address",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "name": "address",
+                              "type": "address"
+                            },
+                            "id": 195,
+                            "name": "ElementaryTypeName",
+                            "src": "1685:7:0"
+                          }
+                        ],
+                        "id": 196,
+                        "name": "VariableDeclaration",
+                        "src": "1685:15:0"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "member_name": "head",
+                          "referencedDeclaration": 8,
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 192,
+                              "type": "struct AddressSet.Data storage pointer",
+                              "value": "self"
+                            },
+                            "id": 197,
+                            "name": "Identifier",
+                            "src": "1703:4:0"
+                          }
+                        ],
+                        "id": 198,
+                        "name": "MemberAccess",
+                        "src": "1703:9:0"
+                      }
+                    ],
+                    "id": 199,
+                    "name": "VariableDeclarationStatement",
+                    "src": "1685:27:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "!=",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 196,
+                              "type": "address",
+                              "value": "current"
+                            },
+                            "id": 200,
+                            "name": "Identifier",
+                            "src": "1730:7:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "isStructConstructorCall": false,
+                              "lValueRequested": false,
+                              "names": [null],
+                              "type": "address",
+                              "type_conversion": true
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": [
+                                    {
+                                      "typeIdentifier": "t_rational_0_by_1",
+                                      "typeString": "int_const 0"
+                                    }
+                                  ],
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "type": "type(address)",
+                                  "value": "address"
+                                },
+                                "id": 201,
+                                "name": "ElementaryTypeNameExpression",
+                                "src": "1741:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 202,
+                                "name": "Literal",
+                                "src": "1749:1:0"
+                              }
+                            ],
+                            "id": 203,
+                            "name": "FunctionCall",
+                            "src": "1741:10:0"
+                          }
+                        ],
+                        "id": 204,
+                        "name": "BinaryOperation",
+                        "src": "1730:21:0"
+                      },
+                      {
+                        "children": [
+                          {
+                            "attributes": {
+                              "assignments": [206]
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "constant": false,
+                                  "name": "next",
+                                  "scope": 238,
+                                  "stateVariable": false,
+                                  "storageLocation": "default",
+                                  "type": "address",
+                                  "value": null,
+                                  "visibility": "internal"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "name": "address",
+                                      "type": "address"
+                                    },
+                                    "id": 205,
+                                    "name": "ElementaryTypeName",
+                                    "src": "1767:7:0"
+                                  }
+                                ],
+                                "id": 206,
+                                "name": "VariableDeclaration",
+                                "src": "1767:12:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "next",
+                                  "referencedDeclaration": 5,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "type":
+                                        "struct AddressSet.Link storage ref"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "member_name": "links",
+                                          "referencedDeclaration": 16,
+                                          "type":
+                                            "mapping(address => struct AddressSet.Link storage ref)"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 192,
+                                              "type":
+                                                "struct AddressSet.Data storage pointer",
+                                              "value": "self"
+                                            },
+                                            "id": 207,
+                                            "name": "Identifier",
+                                            "src": "1782:4:0"
+                                          }
+                                        ],
+                                        "id": 208,
+                                        "name": "MemberAccess",
+                                        "src": "1782:10:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 196,
+                                          "type": "address",
+                                          "value": "current"
+                                        },
+                                        "id": 209,
+                                        "name": "Identifier",
+                                        "src": "1793:7:0"
+                                      }
+                                    ],
+                                    "id": 210,
+                                    "name": "IndexAccess",
+                                    "src": "1782:19:0"
+                                  }
+                                ],
+                                "id": 211,
+                                "name": "MemberAccess",
+                                "src": "1782:24:0"
+                              }
+                            ],
+                            "id": 212,
+                            "name": "VariableDeclarationStatement",
+                            "src": "1767:39:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "delete",
+                                  "prefix": true,
+                                  "type": "tuple()"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": true,
+                                      "type":
+                                        "struct AddressSet.Link storage ref"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "member_name": "links",
+                                          "referencedDeclaration": 16,
+                                          "type":
+                                            "mapping(address => struct AddressSet.Link storage ref)"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 192,
+                                              "type":
+                                                "struct AddressSet.Data storage pointer",
+                                              "value": "self"
+                                            },
+                                            "id": 213,
+                                            "name": "Identifier",
+                                            "src": "1827:4:0"
+                                          }
+                                        ],
+                                        "id": 214,
+                                        "name": "MemberAccess",
+                                        "src": "1827:10:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 196,
+                                          "type": "address",
+                                          "value": "current"
+                                        },
+                                        "id": 215,
+                                        "name": "Identifier",
+                                        "src": "1838:7:0"
+                                      }
+                                    ],
+                                    "id": 216,
+                                    "name": "IndexAccess",
+                                    "src": "1827:19:0"
+                                  }
+                                ],
+                                "id": 217,
+                                "name": "UnaryOperation",
+                                "src": "1820:26:0"
+                              }
+                            ],
+                            "id": 218,
+                            "name": "ExpressionStatement",
+                            "src": "1820:26:0"
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "=",
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 196,
+                                      "type": "address",
+                                      "value": "current"
+                                    },
+                                    "id": 219,
+                                    "name": "Identifier",
+                                    "src": "1860:7:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 206,
+                                      "type": "address",
+                                      "value": "next"
+                                    },
+                                    "id": 220,
+                                    "name": "Identifier",
+                                    "src": "1870:4:0"
+                                  }
+                                ],
+                                "id": 221,
+                                "name": "Assignment",
+                                "src": "1860:14:0"
+                              }
+                            ],
+                            "id": 222,
+                            "name": "ExpressionStatement",
+                            "src": "1860:14:0"
+                          }
+                        ],
+                        "id": 223,
+                        "name": "Block",
+                        "src": "1753:132:0"
+                      }
+                    ],
+                    "id": 224,
+                    "name": "WhileStatement",
+                    "src": "1723:162:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "delete",
+                          "prefix": true,
+                          "type": "tuple()"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "head",
+                              "referencedDeclaration": 8,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 192,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 225,
+                                "name": "Identifier",
+                                "src": "1902:4:0"
+                              }
+                            ],
+                            "id": 226,
+                            "name": "MemberAccess",
+                            "src": "1902:9:0"
+                          }
+                        ],
+                        "id": 227,
+                        "name": "UnaryOperation",
+                        "src": "1895:16:0"
+                      }
+                    ],
+                    "id": 228,
+                    "name": "ExpressionStatement",
+                    "src": "1895:16:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "delete",
+                          "prefix": true,
+                          "type": "tuple()"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "tail",
+                              "referencedDeclaration": 10,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 192,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 229,
+                                "name": "Identifier",
+                                "src": "1928:4:0"
+                              }
+                            ],
+                            "id": 230,
+                            "name": "MemberAccess",
+                            "src": "1928:9:0"
+                          }
+                        ],
+                        "id": 231,
+                        "name": "UnaryOperation",
+                        "src": "1921:16:0"
+                      }
+                    ],
+                    "id": 232,
+                    "name": "ExpressionStatement",
+                    "src": "1921:16:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "delete",
+                          "prefix": true,
+                          "type": "tuple()"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "count",
+                              "referencedDeclaration": 12,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 192,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 233,
+                                "name": "Identifier",
+                                "src": "1954:4:0"
+                              }
+                            ],
+                            "id": 234,
+                            "name": "MemberAccess",
+                            "src": "1954:10:0"
+                          }
+                        ],
+                        "id": 235,
+                        "name": "UnaryOperation",
+                        "src": "1947:17:0"
+                      }
+                    ],
+                    "id": 236,
+                    "name": "ExpressionStatement",
+                    "src": "1947:17:0"
+                  }
+                ],
+                "id": 237,
+                "name": "Block",
+                "src": "1675:296:0"
+              }
+            ],
+            "id": 238,
+            "name": "FunctionDefinition",
+            "src": "1632:339:0"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "getNext",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 254,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 239,
+                        "name": "UserDefinedTypeName",
+                        "src": "2035:4:0"
+                      }
+                    ],
+                    "id": 240,
+                    "name": "VariableDeclaration",
+                    "src": "2035:17:0"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "current",
+                      "scope": 254,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 241,
+                        "name": "ElementaryTypeName",
+                        "src": "2062:7:0"
+                      }
+                    ],
+                    "id": 242,
+                    "name": "VariableDeclaration",
+                    "src": "2062:15:0"
+                  }
+                ],
+                "id": 243,
+                "name": "ParameterList",
+                "src": "2025:58:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 254,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 244,
+                        "name": "ElementaryTypeName",
+                        "src": "2131:7:0"
+                      }
+                    ],
+                    "id": 245,
+                    "name": "VariableDeclaration",
+                    "src": "2131:7:0"
+                  }
+                ],
+                "id": 246,
+                "name": "ParameterList",
+                "src": "2130:9:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 246
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "member_name": "next",
+                          "referencedDeclaration": 5,
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "type": "struct AddressSet.Link storage ref"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "links",
+                                  "referencedDeclaration": 16,
+                                  "type":
+                                    "mapping(address => struct AddressSet.Link storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 240,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 247,
+                                    "name": "Identifier",
+                                    "src": "2161:4:0"
+                                  }
+                                ],
+                                "id": 248,
+                                "name": "MemberAccess",
+                                "src": "2161:10:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 242,
+                                  "type": "address",
+                                  "value": "current"
+                                },
+                                "id": 249,
+                                "name": "Identifier",
+                                "src": "2172:7:0"
+                              }
+                            ],
+                            "id": 250,
+                            "name": "IndexAccess",
+                            "src": "2161:19:0"
+                          }
+                        ],
+                        "id": 251,
+                        "name": "MemberAccess",
+                        "src": "2161:24:0"
+                      }
+                    ],
+                    "id": 252,
+                    "name": "Return",
+                    "src": "2154:31:0"
+                  }
+                ],
+                "id": 253,
+                "name": "Block",
+                "src": "2144:48:0"
+              }
+            ],
+            "id": 254,
+            "name": "FunctionDefinition",
+            "src": "2009:183:0"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "getPrevious",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 270,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 255,
+                        "name": "UserDefinedTypeName",
+                        "src": "2228:4:0"
+                      }
+                    ],
+                    "id": 256,
+                    "name": "VariableDeclaration",
+                    "src": "2228:17:0"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "current",
+                      "scope": 270,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 257,
+                        "name": "ElementaryTypeName",
+                        "src": "2255:7:0"
+                      }
+                    ],
+                    "id": 258,
+                    "name": "VariableDeclaration",
+                    "src": "2255:15:0"
+                  }
+                ],
+                "id": 259,
+                "name": "ParameterList",
+                "src": "2218:58:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 270,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 260,
+                        "name": "ElementaryTypeName",
+                        "src": "2324:7:0"
+                      }
+                    ],
+                    "id": 261,
+                    "name": "VariableDeclaration",
+                    "src": "2324:7:0"
+                  }
+                ],
+                "id": 262,
+                "name": "ParameterList",
+                "src": "2323:9:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 262
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "member_name": "previous",
+                          "referencedDeclaration": 3,
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "type": "struct AddressSet.Link storage ref"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "links",
+                                  "referencedDeclaration": 16,
+                                  "type":
+                                    "mapping(address => struct AddressSet.Link storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 256,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 263,
+                                    "name": "Identifier",
+                                    "src": "2354:4:0"
+                                  }
+                                ],
+                                "id": 264,
+                                "name": "MemberAccess",
+                                "src": "2354:10:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 258,
+                                  "type": "address",
+                                  "value": "current"
+                                },
+                                "id": 265,
+                                "name": "Identifier",
+                                "src": "2365:7:0"
+                              }
+                            ],
+                            "id": 266,
+                            "name": "IndexAccess",
+                            "src": "2354:19:0"
+                          }
+                        ],
+                        "id": 267,
+                        "name": "MemberAccess",
+                        "src": "2354:28:0"
+                      }
+                    ],
+                    "id": 268,
+                    "name": "Return",
+                    "src": "2347:35:0"
+                  }
+                ],
+                "id": 269,
+                "name": "Block",
+                "src": "2337:52:0"
+              }
+            ],
+            "id": 270,
+            "name": "FunctionDefinition",
+            "src": "2198:191:0"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "contains",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 295,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 271,
+                        "name": "UserDefinedTypeName",
+                        "src": "2422:4:0"
+                      }
+                    ],
+                    "id": 272,
+                    "name": "VariableDeclaration",
+                    "src": "2422:17:0"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "element",
+                      "scope": 295,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 273,
+                        "name": "ElementaryTypeName",
+                        "src": "2449:7:0"
+                      }
+                    ],
+                    "id": 274,
+                    "name": "VariableDeclaration",
+                    "src": "2449:15:0"
+                  }
+                ],
+                "id": 275,
+                "name": "ParameterList",
+                "src": "2412:58:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 295,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bool",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bool",
+                          "type": "bool"
+                        },
+                        "id": 276,
+                        "name": "ElementaryTypeName",
+                        "src": "2518:4:0"
+                      }
+                    ],
+                    "id": 277,
+                    "name": "VariableDeclaration",
+                    "src": "2518:4:0"
+                  }
+                ],
+                "id": 278,
+                "name": "ParameterList",
+                "src": "2517:6:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 278
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "||",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "==",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 274,
+                                  "type": "address",
+                                  "value": "element"
+                                },
+                                "id": 279,
+                                "name": "Identifier",
+                                "src": "2545:7:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "head",
+                                  "referencedDeclaration": 8,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 272,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 280,
+                                    "name": "Identifier",
+                                    "src": "2556:4:0"
+                                  }
+                                ],
+                                "id": 281,
+                                "name": "MemberAccess",
+                                "src": "2556:9:0"
+                              }
+                            ],
+                            "id": 282,
+                            "name": "BinaryOperation",
+                            "src": "2545:20:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "previous",
+                                  "referencedDeclaration": 3,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "type":
+                                        "struct AddressSet.Link storage ref"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "member_name": "links",
+                                          "referencedDeclaration": 16,
+                                          "type":
+                                            "mapping(address => struct AddressSet.Link storage ref)"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 272,
+                                              "type":
+                                                "struct AddressSet.Data storage pointer",
+                                              "value": "self"
+                                            },
+                                            "id": 283,
+                                            "name": "Identifier",
+                                            "src": "2581:4:0"
+                                          }
+                                        ],
+                                        "id": 284,
+                                        "name": "MemberAccess",
+                                        "src": "2581:10:0"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 274,
+                                          "type": "address",
+                                          "value": "element"
+                                        },
+                                        "id": 285,
+                                        "name": "Identifier",
+                                        "src": "2592:7:0"
+                                      }
+                                    ],
+                                    "id": 286,
+                                    "name": "IndexAccess",
+                                    "src": "2581:19:0"
+                                  }
+                                ],
+                                "id": 287,
+                                "name": "MemberAccess",
+                                "src": "2581:28:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "address",
+                                  "type_conversion": true
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(address)",
+                                      "value": "address"
+                                    },
+                                    "id": 288,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "2613:7:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 289,
+                                    "name": "Literal",
+                                    "src": "2621:1:0"
+                                  }
+                                ],
+                                "id": 290,
+                                "name": "FunctionCall",
+                                "src": "2613:10:0"
+                              }
+                            ],
+                            "id": 291,
+                            "name": "BinaryOperation",
+                            "src": "2581:42:0"
+                          }
+                        ],
+                        "id": 292,
+                        "name": "BinaryOperation",
+                        "src": "2545:78:0"
+                      }
+                    ],
+                    "id": 293,
+                    "name": "Return",
+                    "src": "2538:85:0"
+                  }
+                ],
+                "id": 294,
+                "name": "Block",
+                "src": "2528:102:0"
+              }
+            ],
+            "id": 295,
+            "name": "FunctionDefinition",
+            "src": "2395:235:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "safeIncrement",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "private"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 316,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 296,
+                        "name": "UserDefinedTypeName",
+                        "src": "2695:4:0"
+                      }
+                    ],
+                    "id": 297,
+                    "name": "VariableDeclaration",
+                    "src": "2695:17:0"
+                  }
+                ],
+                "id": 298,
+                "name": "ParameterList",
+                "src": "2694:19:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 299,
+                "name": "ParameterList",
+                "src": "2722:0:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 680,
+                              "type": "function (bool) pure",
+                              "value": "assert"
+                            },
+                            "id": 300,
+                            "name": "Identifier",
+                            "src": "2732:6:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "commonType": {
+                                    "typeIdentifier": "t_uint256",
+                                    "typeString": "uint256"
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "+",
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "count",
+                                      "referencedDeclaration": 12,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 297,
+                                          "type":
+                                            "struct AddressSet.Data storage pointer",
+                                          "value": "self"
+                                        },
+                                        "id": 301,
+                                        "name": "Identifier",
+                                        "src": "2739:4:0"
+                                      }
+                                    ],
+                                    "id": 302,
+                                    "name": "MemberAccess",
+                                    "src": "2739:10:0"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "31",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 1",
+                                      "value": "1"
+                                    },
+                                    "id": 303,
+                                    "name": "Literal",
+                                    "src": "2752:1:0"
+                                  }
+                                ],
+                                "id": 304,
+                                "name": "BinaryOperation",
+                                "src": "2739:14:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "count",
+                                  "referencedDeclaration": 12,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 297,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 305,
+                                    "name": "Identifier",
+                                    "src": "2756:4:0"
+                                  }
+                                ],
+                                "id": 306,
+                                "name": "MemberAccess",
+                                "src": "2756:10:0"
+                              }
+                            ],
+                            "id": 307,
+                            "name": "BinaryOperation",
+                            "src": "2739:27:0"
+                          }
+                        ],
+                        "id": 308,
+                        "name": "FunctionCall",
+                        "src": "2732:35:0"
+                      }
+                    ],
+                    "id": 309,
+                    "name": "ExpressionStatement",
+                    "src": "2732:35:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "++",
+                          "prefix": false,
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "count",
+                              "referencedDeclaration": 12,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 297,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 310,
+                                "name": "Identifier",
+                                "src": "2777:4:0"
+                              }
+                            ],
+                            "id": 312,
+                            "name": "MemberAccess",
+                            "src": "2777:10:0"
+                          }
+                        ],
+                        "id": 313,
+                        "name": "UnaryOperation",
+                        "src": "2777:12:0"
+                      }
+                    ],
+                    "id": 314,
+                    "name": "ExpressionStatement",
+                    "src": "2777:12:0"
+                  }
+                ],
+                "id": 315,
+                "name": "Block",
+                "src": "2722:74:0"
+              }
+            ],
+            "id": 316,
+            "name": "FunctionDefinition",
+            "src": "2672:124:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "safeDecrement",
+              "payable": false,
+              "scope": 335,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "private"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "self",
+                      "scope": 334,
+                      "stateVariable": false,
+                      "storageLocation": "storage",
+                      "type": "struct AddressSet.Data storage pointer",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "contractScope": null,
+                          "name": "Data",
+                          "referencedDeclaration": 17,
+                          "type": "struct AddressSet.Data storage pointer"
+                        },
+                        "id": 317,
+                        "name": "UserDefinedTypeName",
+                        "src": "2825:4:0"
+                      }
+                    ],
+                    "id": 318,
+                    "name": "VariableDeclaration",
+                    "src": "2825:17:0"
+                  }
+                ],
+                "id": 319,
+                "name": "ParameterList",
+                "src": "2824:19:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 320,
+                "name": "ParameterList",
+                "src": "2852:0:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 680,
+                              "type": "function (bool) pure",
+                              "value": "assert"
+                            },
+                            "id": 321,
+                            "name": "Identifier",
+                            "src": "2862:6:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "count",
+                                  "referencedDeclaration": 12,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 318,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "self"
+                                    },
+                                    "id": 322,
+                                    "name": "Identifier",
+                                    "src": "2869:4:0"
+                                  }
+                                ],
+                                "id": 323,
+                                "name": "MemberAccess",
+                                "src": "2869:10:0"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 324,
+                                "name": "Literal",
+                                "src": "2882:1:0"
+                              }
+                            ],
+                            "id": 325,
+                            "name": "BinaryOperation",
+                            "src": "2869:14:0"
+                          }
+                        ],
+                        "id": 326,
+                        "name": "FunctionCall",
+                        "src": "2862:22:0"
+                      }
+                    ],
+                    "id": 327,
+                    "name": "ExpressionStatement",
+                    "src": "2862:22:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "--",
+                          "prefix": false,
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "member_name": "count",
+                              "referencedDeclaration": 12,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 318,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "self"
+                                },
+                                "id": 328,
+                                "name": "Identifier",
+                                "src": "2894:4:0"
+                              }
+                            ],
+                            "id": 330,
+                            "name": "MemberAccess",
+                            "src": "2894:10:0"
+                          }
+                        ],
+                        "id": 331,
+                        "name": "UnaryOperation",
+                        "src": "2894:12:0"
+                      }
+                    ],
+                    "id": 332,
+                    "name": "ExpressionStatement",
+                    "src": "2894:12:0"
+                  }
+                ],
+                "id": 333,
+                "name": "Block",
+                "src": "2852:61:0"
+              }
+            ],
+            "id": 334,
+            "name": "FunctionDefinition",
+            "src": "2802:111:0"
+          }
+        ],
+        "id": 335,
+        "name": "ContractDefinition",
+        "src": "26:2889:0"
+      }
+    ],
+    "id": 336,
+    "name": "SourceUnit",
+    "src": "0:2917:0"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "1.0.1",
+  "updatedAt": "2017-11-04T18:31:33.342Z"
+}

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -1,0 +1,776 @@
+{
+  "contractName": "Migrations",
+  "abi": [
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "upgrade",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "lastCompletedMigration",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "completed",
+          "type": "uint256"
+        }
+      ],
+      "name": "setCompleted",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    }
+  ],
+  "bytecode":
+    "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f010146100675780638da5cb5b146100a0578063fbdbad3c146100f5578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561010057600080fd5b610108610249565b6040518082815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a723058203cbbd5e80785b10e36a0d14272f33789450d2fa854c858a4c075e8f1d249b09a0029",
+  "deployedBytecode":
+    "0x606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f010146100675780638da5cb5b146100a0578063fbdbad3c146100f5578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561010057600080fd5b610108610249565b6040518082815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a723058203cbbd5e80785b10e36a0d14272f33789450d2fa854c858a4c075e8f1d249b09a0029",
+  "sourceMap":
+    "26:545:1:-;;;215:64;;;;;;;;262:10;254:5;;:18;;;;;;;;;;;;;;;;;;26:545;;;;;;",
+  "deployedSourceMap":
+    "26:545:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;398:171;;;;;;;;;;;;;;;;;;;;;;;;;;;;53:20;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;79:34;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;285:107;;;;;;;;;;;;;;;;;;;;;;;;;;398:171;463:19;170:5;;;;;;;;;;;156:19;;:10;:19;;;152:51;;;496:10;463:44;;517:8;:21;;;539:22;;517:45;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;152:51;398:171;;:::o;53:20::-;;;;;;;;;;;;;:::o;79:34::-;;;;:::o;285:107::-;170:5;;;;;;;;;;;156:19;;:10;:19;;;152:51;;;376:9;351:22;:34;;;;152:51;285:107;:::o",
+  "source":
+    "pragma solidity 0.4.18;\n\n\ncontract Migrations {\n\n    address public owner;\n    uint public lastCompletedMigration;\n\n    modifier restricted() {\n        if (msg.sender == owner) {\n            _;\n        }\n    }\n\n    function Migrations() public {\n        owner = msg.sender;\n    }\n\n    function setCompleted(uint completed) public restricted {\n        lastCompletedMigration = completed;\n    }\n\n    function upgrade(address newAddress) public restricted {\n        Migrations upgraded = Migrations(newAddress);\n        upgraded.setCompleted(lastCompletedMigration);\n    }\n}\n",
+  "sourcePath":
+    "/home/biern/projects/signhash/signhash-contracts/contracts/Migrations.sol",
+  "ast": {
+    "attributes": {
+      "absolutePath":
+        "/home/biern/projects/signhash/signhash-contracts/contracts/Migrations.sol",
+      "exportedSymbols": {
+        "Migrations": [393]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": ["solidity", "0.4", ".18", ".18"]
+        },
+        "id": 337,
+        "name": "PragmaDirective",
+        "src": "0:23:1"
+      },
+      {
+        "attributes": {
+          "baseContracts": [null],
+          "contractDependencies": [null],
+          "contractKind": "contract",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [393],
+          "name": "Migrations",
+          "scope": 394
+        },
+        "children": [
+          {
+            "attributes": {
+              "constant": false,
+              "name": "owner",
+              "scope": 393,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "address",
+              "value": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "name": "address",
+                  "type": "address"
+                },
+                "id": 338,
+                "name": "ElementaryTypeName",
+                "src": "53:7:1"
+              }
+            ],
+            "id": 339,
+            "name": "VariableDeclaration",
+            "src": "53:20:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "lastCompletedMigration",
+              "scope": 393,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "uint256",
+              "value": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "name": "uint",
+                  "type": "uint256"
+                },
+                "id": 340,
+                "name": "ElementaryTypeName",
+                "src": "79:4:1"
+              }
+            ],
+            "id": 341,
+            "name": "VariableDeclaration",
+            "src": "79:34:1"
+          },
+          {
+            "attributes": {
+              "name": "restricted",
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 342,
+                "name": "ParameterList",
+                "src": "139:2:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "falseBody": null
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "==",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 343,
+                                "name": "Identifier",
+                                "src": "156:3:1"
+                              }
+                            ],
+                            "id": 344,
+                            "name": "MemberAccess",
+                            "src": "156:10:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 339,
+                              "type": "address",
+                              "value": "owner"
+                            },
+                            "id": 345,
+                            "name": "Identifier",
+                            "src": "170:5:1"
+                          }
+                        ],
+                        "id": 346,
+                        "name": "BinaryOperation",
+                        "src": "156:19:1"
+                      },
+                      {
+                        "children": [
+                          {
+                            "id": 347,
+                            "name": "PlaceholderStatement",
+                            "src": "191:1:1"
+                          }
+                        ],
+                        "id": 348,
+                        "name": "Block",
+                        "src": "177:26:1"
+                      }
+                    ],
+                    "id": 349,
+                    "name": "IfStatement",
+                    "src": "152:51:1"
+                  }
+                ],
+                "id": 350,
+                "name": "Block",
+                "src": "142:67:1"
+              }
+            ],
+            "id": 351,
+            "name": "ModifierDefinition",
+            "src": "120:89:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": true,
+              "modifiers": [null],
+              "name": "Migrations",
+              "payable": false,
+              "scope": 393,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 352,
+                "name": "ParameterList",
+                "src": "234:2:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 353,
+                "name": "ParameterList",
+                "src": "244:0:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 339,
+                              "type": "address",
+                              "value": "owner"
+                            },
+                            "id": 354,
+                            "name": "Identifier",
+                            "src": "254:5:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 355,
+                                "name": "Identifier",
+                                "src": "262:3:1"
+                              }
+                            ],
+                            "id": 356,
+                            "name": "MemberAccess",
+                            "src": "262:10:1"
+                          }
+                        ],
+                        "id": 357,
+                        "name": "Assignment",
+                        "src": "254:18:1"
+                      }
+                    ],
+                    "id": 358,
+                    "name": "ExpressionStatement",
+                    "src": "254:18:1"
+                  }
+                ],
+                "id": 359,
+                "name": "Block",
+                "src": "244:35:1"
+              }
+            ],
+            "id": 360,
+            "name": "FunctionDefinition",
+            "src": "215:64:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "name": "setCompleted",
+              "payable": false,
+              "scope": 393,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "completed",
+                      "scope": 372,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint",
+                          "type": "uint256"
+                        },
+                        "id": 361,
+                        "name": "ElementaryTypeName",
+                        "src": "307:4:1"
+                      }
+                    ],
+                    "id": 362,
+                    "name": "VariableDeclaration",
+                    "src": "307:14:1"
+                  }
+                ],
+                "id": 363,
+                "name": "ParameterList",
+                "src": "306:16:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 366,
+                "name": "ParameterList",
+                "src": "341:0:1"
+              },
+              {
+                "attributes": {
+                  "arguments": [null]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "argumentTypes": null,
+                      "overloadedDeclarations": [null],
+                      "referencedDeclaration": 351,
+                      "type": "modifier ()",
+                      "value": "restricted"
+                    },
+                    "id": 364,
+                    "name": "Identifier",
+                    "src": "330:10:1"
+                  }
+                ],
+                "id": 365,
+                "name": "ModifierInvocation",
+                "src": "330:10:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 341,
+                              "type": "uint256",
+                              "value": "lastCompletedMigration"
+                            },
+                            "id": 367,
+                            "name": "Identifier",
+                            "src": "351:22:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 362,
+                              "type": "uint256",
+                              "value": "completed"
+                            },
+                            "id": 368,
+                            "name": "Identifier",
+                            "src": "376:9:1"
+                          }
+                        ],
+                        "id": 369,
+                        "name": "Assignment",
+                        "src": "351:34:1"
+                      }
+                    ],
+                    "id": 370,
+                    "name": "ExpressionStatement",
+                    "src": "351:34:1"
+                  }
+                ],
+                "id": 371,
+                "name": "Block",
+                "src": "341:51:1"
+              }
+            ],
+            "id": 372,
+            "name": "FunctionDefinition",
+            "src": "285:107:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "name": "upgrade",
+              "payable": false,
+              "scope": 393,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "newAddress",
+                      "scope": 392,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 373,
+                        "name": "ElementaryTypeName",
+                        "src": "415:7:1"
+                      }
+                    ],
+                    "id": 374,
+                    "name": "VariableDeclaration",
+                    "src": "415:18:1"
+                  }
+                ],
+                "id": 375,
+                "name": "ParameterList",
+                "src": "414:20:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 378,
+                "name": "ParameterList",
+                "src": "453:0:1"
+              },
+              {
+                "attributes": {
+                  "arguments": [null]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "argumentTypes": null,
+                      "overloadedDeclarations": [null],
+                      "referencedDeclaration": 351,
+                      "type": "modifier ()",
+                      "value": "restricted"
+                    },
+                    "id": 376,
+                    "name": "Identifier",
+                    "src": "442:10:1"
+                  }
+                ],
+                "id": 377,
+                "name": "ModifierInvocation",
+                "src": "442:10:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "assignments": [380]
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "upgraded",
+                          "scope": 392,
+                          "stateVariable": false,
+                          "storageLocation": "default",
+                          "type": "contract Migrations",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "contractScope": null,
+                              "name": "Migrations",
+                              "referencedDeclaration": 393,
+                              "type": "contract Migrations"
+                            },
+                            "id": 379,
+                            "name": "UserDefinedTypeName",
+                            "src": "463:10:1"
+                          }
+                        ],
+                        "id": 380,
+                        "name": "VariableDeclaration",
+                        "src": "463:19:1"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "contract Migrations",
+                          "type_conversion": true
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 393,
+                              "type": "type(contract Migrations)",
+                              "value": "Migrations"
+                            },
+                            "id": 381,
+                            "name": "Identifier",
+                            "src": "485:10:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 374,
+                              "type": "address",
+                              "value": "newAddress"
+                            },
+                            "id": 382,
+                            "name": "Identifier",
+                            "src": "496:10:1"
+                          }
+                        ],
+                        "id": 383,
+                        "name": "FunctionCall",
+                        "src": "485:22:1"
+                      }
+                    ],
+                    "id": 384,
+                    "name": "VariableDeclarationStatement",
+                    "src": "463:44:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_uint256",
+                                  "typeString": "uint256"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "setCompleted",
+                              "referencedDeclaration": 372,
+                              "type": "function (uint256) external"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 380,
+                                  "type": "contract Migrations",
+                                  "value": "upgraded"
+                                },
+                                "id": 385,
+                                "name": "Identifier",
+                                "src": "517:8:1"
+                              }
+                            ],
+                            "id": 387,
+                            "name": "MemberAccess",
+                            "src": "517:21:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 341,
+                              "type": "uint256",
+                              "value": "lastCompletedMigration"
+                            },
+                            "id": 388,
+                            "name": "Identifier",
+                            "src": "539:22:1"
+                          }
+                        ],
+                        "id": 389,
+                        "name": "FunctionCall",
+                        "src": "517:45:1"
+                      }
+                    ],
+                    "id": 390,
+                    "name": "ExpressionStatement",
+                    "src": "517:45:1"
+                  }
+                ],
+                "id": 391,
+                "name": "Block",
+                "src": "453:116:1"
+              }
+            ],
+            "id": 392,
+            "name": "FunctionDefinition",
+            "src": "398:171:1"
+          }
+        ],
+        "id": 393,
+        "name": "ContractDefinition",
+        "src": "26:545:1"
+      }
+    ],
+    "id": 394,
+    "name": "SourceUnit",
+    "src": "0:572:1"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "1.0.1",
+  "updatedAt": "2017-11-04T18:31:33.323Z"
+}

--- a/build/contracts/SignHash.json
+++ b/build/contracts/SignHash.json
@@ -1,0 +1,6147 @@
+{
+  "contractName": "SignHash",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "hash",
+          "type": "bytes32"
+        },
+        {
+          "name": "maxCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSigners",
+      "outputs": [
+        {
+          "name": "result",
+          "type": "address[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "name": "method",
+          "type": "string"
+        }
+      ],
+      "name": "getProof",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "hash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "sign",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "method",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "type": "string"
+        }
+      ],
+      "name": "addProof",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "method",
+          "type": "string"
+        }
+      ],
+      "name": "removeProof",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "hash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "revoke",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "hash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "event",
+      "anonymous": false,
+      "name": "Signed"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "hash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        }
+      ],
+      "name": "Revoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "method",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "value",
+          "type": "string"
+        }
+      ],
+      "name": "ProofAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "method",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "value",
+          "type": "string"
+        }
+      ],
+      "name": "ProofRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "method",
+          "type": "string"
+        }
+      ],
+      "name": "ProofRemoved",
+      "type": "event"
+    }
+  ],
+  "bytecode":
+    "0x6060604052341561000f57600080fd5b6115918061001e6000396000f300606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806330a1a80b1461007d57806343d9421a14610102578063799cd333146101f75780637bb0350c1461021e5780637c07e2fc146102be578063b75c7dc61461031b575b600080fd5b341561008857600080fd5b6100ab600480803560001916906020019091908035906020019091905050610342565b6040518080602001828103825283818151815260200191508051906020019060200280838360005b838110156100ee5780820151818401526020810190506100d3565b505050509050019250505060405180910390f35b341561010d57600080fd5b61017c600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001908201803590602001908080601f0160208091040260200160405190810160405280939291908181526020018383808284378201915050505050509190505061047c565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156101bc5780820151818401526020810190506101a1565b50505050905090810190601f1680156101e95780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561020257600080fd5b61021c6004808035600019169060200190919050506105cd565b005b341561022957600080fd5b6102bc600480803590602001908201803590602001908080601f0160208091040260200160405190810160405280939291908181526020018383808284378201915050505050509190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610660565b005b34156102c957600080fd5b610319600480803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610861565b005b341561032657600080fd5b610340600480803560001916906020019091905050610aab565b005b61034a611450565b6000806000806000876000191660001916815260200190815260200160002092506000836002015411156104735782600201548510156103aa57846040518059106103925750595b908082528060200260200182016040525093506103d0565b82600201546040518059106103bc5750595b908082528060200260200182016040525093505b8260000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff169150600090505b83518110156104725781848281518110151561041457fe5b9060200190602002019073ffffffffffffffffffffffffffffffffffffffff16908173ffffffffffffffffffffffffffffffffffffffff16815250506104638284610b3e90919063ffffffff16565b915080806001019150506103fc565b5b50505092915050565b610484611464565b600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156104f957805182526020820191506020810190506020830392506104d4565b6001836020036101000a03801982511681845116808217855250505050505090500191505090815260200160405180910390208054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105c05780601f10610595576101008083540402835291602001916105c0565b820191906000526020600020905b8154815290600101906020018083116105a357829003601f168201915b5050505050905092915050565b6000600102600019168160001916141515156105e857600080fd5b610614336000808460001916600019168152602001908152602001600020610bad90919063ffffffff16565b503373ffffffffffffffffffffffffffffffffffffffff1681600019167fdc9da68bd73c4161c8f5bc195573e6649390acdb7090a16542862b767eacac5a60405160405180910390a350565b6000825111151561067057600080fd5b6000815111151561068057600080fd5b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020836040518082805190602001908083835b6020831015156106f657805182526020820191506020810190506020830392506106d1565b6001836020036101000a0380198251168184511680821785525050505050509050019150509081526020016040518091039020908051906020019061073c929190611478565b503373ffffffffffffffffffffffffffffffffffffffff167f967a81fb8dbc39bdd0222a448199b528519dace7cf245030352b06219110cac48383604051808060200180602001838103835285818151815260200191508051906020019080838360005b838110156107bb5780820151818401526020810190506107a0565b50505050905090810190601f1680156107e85780820380516001836020036101000a031916815260200191505b50838103825284818151815260200191508051906020019080838360005b83811015610821578082015181840152602081019050610806565b50505050905090810190601f16801561084e5780820380516001836020036101000a031916815260200191505b5094505050505060405180910390a25050565b600080825111151561087257600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156108e757805182526020820191506020810190506020830392506108c2565b6001836020036101000a0380198251168184511680821785525050505050509050019150509081526020016040518091039020905060008180546001816001161561010002031660029004905011151561094057600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156109b55780518252602082019150602081019050602083039250610990565b6001836020036101000a038019825116818451168082178552505050505050905001915050908152602001604051809103902060006109f491906114f8565b3373ffffffffffffffffffffffffffffffffffffffff167f35ac935e2145a5d2057eb6e277a38dcb4e0bad1c7d5941d397be2bcb0c7cc74b836040518080602001828103825283818151815260200191508051906020019080838360005b83811015610a6d578082015181840152602081019050610a52565b50505050905090810190601f168015610a9a5780820380516001836020036101000a031916815260200191505b509250505060405180910390a25050565b600060010260001916816000191614151515610ac657600080fd5b610af2336000808460001916600019168152602001908152602001600020610e4f90919063ffffffff16565b503373ffffffffffffffffffffffffffffffffffffffff1681600019167f5bc2baf870c5baf189838b5e0b0e3b04a3263e2df5d305d1c15f3e6022f5dc4560405160405180910390a350565b60008260030160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16905092915050565b60008073ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff1614151515610bea57600080fd5b600073ffffffffffffffffffffffffffffffffffffffff168360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161415610c8b57818360000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610df8565b610c958383611302565b1515610dee57818360030160008560010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508260010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610df7565b60009050610e49565b5b818360010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610e44836113fb565b600190505b92915050565b600080600073ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff1614151515610e8e57600080fd5b8360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000209050600073ffffffffffffffffffffffffffffffffffffffff168160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16141515610ffb578060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460030160008360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506110c9565b8360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff1614156110bf578060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506110c8565b600091506112fb565b5b600073ffffffffffffffffffffffffffffffffffffffff168160010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161415156111f3578060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460030160008360010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061125b565b8060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505b61126484611428565b8360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff02191690556001820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff02191690555050600191505b5092915050565b60008260000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff1614806113f35750600073ffffffffffffffffffffffffffffffffffffffff168360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614155b905092915050565b8060020154600182600201540111151561141157fe5b806002016000815480929190600101919050555050565b6000816002015411151561143857fe5b80600201600081548092919060019003919050555050565b602060405190810160405280600081525090565b602060405190810160405280600081525090565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106114b957805160ff19168380011785556114e7565b828001600101855582156114e7579182015b828111156114e65782518255916020019190600101906114cb565b5b5090506114f49190611540565b5090565b50805460018160011615610100020316600290046000825580601f1061151e575061153d565b601f01602090049060005260206000209081019061153c9190611540565b5b50565b61156291905b8082111561155e576000816000905550600101611546565b5090565b905600a165627a7a72305820372a8fcc3ad0ae7e7dcc159b30d93dcfe57b3770a0c109970b3c6fa633191f820029",
+  "deployedBytecode":
+    "0x606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806330a1a80b1461007d57806343d9421a14610102578063799cd333146101f75780637bb0350c1461021e5780637c07e2fc146102be578063b75c7dc61461031b575b600080fd5b341561008857600080fd5b6100ab600480803560001916906020019091908035906020019091905050610342565b6040518080602001828103825283818151815260200191508051906020019060200280838360005b838110156100ee5780820151818401526020810190506100d3565b505050509050019250505060405180910390f35b341561010d57600080fd5b61017c600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001908201803590602001908080601f0160208091040260200160405190810160405280939291908181526020018383808284378201915050505050509190505061047c565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156101bc5780820151818401526020810190506101a1565b50505050905090810190601f1680156101e95780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561020257600080fd5b61021c6004808035600019169060200190919050506105cd565b005b341561022957600080fd5b6102bc600480803590602001908201803590602001908080601f0160208091040260200160405190810160405280939291908181526020018383808284378201915050505050509190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610660565b005b34156102c957600080fd5b610319600480803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610861565b005b341561032657600080fd5b610340600480803560001916906020019091905050610aab565b005b61034a611450565b6000806000806000876000191660001916815260200190815260200160002092506000836002015411156104735782600201548510156103aa57846040518059106103925750595b908082528060200260200182016040525093506103d0565b82600201546040518059106103bc5750595b908082528060200260200182016040525093505b8260000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff169150600090505b83518110156104725781848281518110151561041457fe5b9060200190602002019073ffffffffffffffffffffffffffffffffffffffff16908173ffffffffffffffffffffffffffffffffffffffff16815250506104638284610b3e90919063ffffffff16565b915080806001019150506103fc565b5b50505092915050565b610484611464565b600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156104f957805182526020820191506020810190506020830392506104d4565b6001836020036101000a03801982511681845116808217855250505050505090500191505090815260200160405180910390208054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105c05780601f10610595576101008083540402835291602001916105c0565b820191906000526020600020905b8154815290600101906020018083116105a357829003601f168201915b5050505050905092915050565b6000600102600019168160001916141515156105e857600080fd5b610614336000808460001916600019168152602001908152602001600020610bad90919063ffffffff16565b503373ffffffffffffffffffffffffffffffffffffffff1681600019167fdc9da68bd73c4161c8f5bc195573e6649390acdb7090a16542862b767eacac5a60405160405180910390a350565b6000825111151561067057600080fd5b6000815111151561068057600080fd5b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020836040518082805190602001908083835b6020831015156106f657805182526020820191506020810190506020830392506106d1565b6001836020036101000a0380198251168184511680821785525050505050509050019150509081526020016040518091039020908051906020019061073c929190611478565b503373ffffffffffffffffffffffffffffffffffffffff167f967a81fb8dbc39bdd0222a448199b528519dace7cf245030352b06219110cac48383604051808060200180602001838103835285818151815260200191508051906020019080838360005b838110156107bb5780820151818401526020810190506107a0565b50505050905090810190601f1680156107e85780820380516001836020036101000a031916815260200191505b50838103825284818151815260200191508051906020019080838360005b83811015610821578082015181840152602081019050610806565b50505050905090810190601f16801561084e5780820380516001836020036101000a031916815260200191505b5094505050505060405180910390a25050565b600080825111151561087257600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156108e757805182526020820191506020810190506020830392506108c2565b6001836020036101000a0380198251168184511680821785525050505050509050019150509081526020016040518091039020905060008180546001816001161561010002031660029004905011151561094057600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020826040518082805190602001908083835b6020831015156109b55780518252602082019150602081019050602083039250610990565b6001836020036101000a038019825116818451168082178552505050505050905001915050908152602001604051809103902060006109f491906114f8565b3373ffffffffffffffffffffffffffffffffffffffff167f35ac935e2145a5d2057eb6e277a38dcb4e0bad1c7d5941d397be2bcb0c7cc74b836040518080602001828103825283818151815260200191508051906020019080838360005b83811015610a6d578082015181840152602081019050610a52565b50505050905090810190601f168015610a9a5780820380516001836020036101000a031916815260200191505b509250505060405180910390a25050565b600060010260001916816000191614151515610ac657600080fd5b610af2336000808460001916600019168152602001908152602001600020610e4f90919063ffffffff16565b503373ffffffffffffffffffffffffffffffffffffffff1681600019167f5bc2baf870c5baf189838b5e0b0e3b04a3263e2df5d305d1c15f3e6022f5dc4560405160405180910390a350565b60008260030160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16905092915050565b60008073ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff1614151515610bea57600080fd5b600073ffffffffffffffffffffffffffffffffffffffff168360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161415610c8b57818360000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610df8565b610c958383611302565b1515610dee57818360030160008560010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508260010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610df7565b60009050610e49565b5b818360010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610e44836113fb565b600190505b92915050565b600080600073ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff1614151515610e8e57600080fd5b8360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000209050600073ffffffffffffffffffffffffffffffffffffffff168160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16141515610ffb578060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460030160008360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506110c9565b8360000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff1614156110bf578060010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506110c8565b600091506112fb565b5b600073ffffffffffffffffffffffffffffffffffffffff168160010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161415156111f3578060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460030160008360010160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061125b565b8060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff168460010160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505b61126484611428565b8360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff02191690556001820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff02191690555050600191505b5092915050565b60008260000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff1614806113f35750600073ffffffffffffffffffffffffffffffffffffffff168360030160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614155b905092915050565b8060020154600182600201540111151561141157fe5b806002016000815480929190600101919050555050565b6000816002015411151561143857fe5b80600201600081548092919060019003919050555050565b602060405190810160405280600081525090565b602060405190810160405280600081525090565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106114b957805160ff19168380011785556114e7565b828001600101855582156114e7579182015b828111156114e65782518255916020019190600101906114cb565b5b5090506114f49190611540565b5090565b50805460018160011615610100020316600290046000825580601f1061151e575061153d565b601f01602090049060005260206000209081019061153c9190611540565b5b50565b61156291905b8082111561155e576000816000905550600101611546565b5090565b905600a165627a7a72305820372a8fcc3ad0ae7e7dcc159b30d93dcfe57b3770a0c109970b3c6fa633191f820029",
+  "sourceMap": "54:2317:2:-;;;;;;;;;;;;;;;;;",
+  "deployedSourceMap":
+    "54:2317:2:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1571:640;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:2;8:100;;;99:1;94:3;90;84:5;80:1;75:3;71;64:6;52:2;49:1;45:3;40:15;;8:100;;;12:14;3:109;;;;;;;;;;;;;;;;;2217:152:2;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:2;8:100;;;99:1;94:3;90;84:5;80:1;75:3;71;64:6;52:2;49:1;45:3;40:15;;8:100;;;12:14;3:109;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;676:154:2;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1002:239;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1247:282;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;836:160;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1571:640;1668:16;;:::i;:::-;1700:35;1995:15;2048:9;1738:7;:13;1746:4;1738:13;;;;;;;;;;;;;;;;;1700:51;;1785:1;1765:11;:17;;;:21;1761:444;;;1817:11;:17;;;1806:8;:28;1802:179;;;1877:8;1863:23;;;;;;;;;;;;;;;;;;;;;;;;1854:32;;1802:179;;;1948:11;:17;;;1934:32;;;;;;;;;;;;;;;;;;;;;;;;1925:41;;1802:179;2013:11;:16;;;;;;;;;;;;1995:34;;2060:1;2048:13;;2043:152;2067:6;:13;2063:1;:17;2043:152;;;2117:7;2105:6;2112:1;2105:9;;;;;;;;;;;;;;;;;:19;;;;;;;;;;;2152:28;2172:7;2152:11;:19;;:28;;;;:::i;:::-;2142:38;;2082:3;;;;;;;2043:152;;;1761:444;1571:640;;;;;;;:::o;2217:152::-;2311:6;;:::i;:::-;2340;:14;2347:6;2340:14;;;;;;;;;;;;;;;2355:6;2340:22;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:2;51:6;36:153;;;182:3;176:5;171:3;164:6;98:2;93:3;89;82:19;;123:2;118:3;114;107:19;;148:2;143:3;139;132:19;;36:153;;;274:1;267:3;263:2;259:3;254;250;246;315:4;311:3;305;299:5;295:3;356:4;350:3;344:5;340:3;389:7;380;377:2;372:3;365:6;3:399;;;;;;;;;;;;;;;;;;;;;;;;2333:29:2;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2217:152;;;;:::o;676:154::-;745:1;737:10;;729:18;;;:4;:18;;;;;721:27;;;;;;;;759:29;777:10;759:7;:13;767:4;759:13;;;;;;;;;;;;;;;;;:17;;:29;;;;:::i;:::-;;812:10;799:24;;806:4;799:24;;;;;;;;;;;;;676:154;:::o;1002:239::-;1097:1;1080:6;1074:20;:24;1066:33;;;;;;;;1139:1;1123:5;1117:19;:23;1109:32;;;;;;;;1181:5;1152:6;:18;1159:10;1152:18;;;;;;;;;;;;;;;1171:6;1152:26;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:2;51:6;36:153;;;182:3;176:5;171:3;164:6;98:2;93:3;89;82:19;;123:2;118:3;114;107:19;;148:2;143:3;139;132:19;;36:153;;;274:1;267:3;263:2;259:3;254;250;246;315:4;311:3;305;299:5;295:3;356:4;350:3;344:5;340:3;389:7;380;377:2;372:3;365:6;3:399;;;;;;;;;;;;;;;;;;;;;;;;1152:34:2;;;;;;;;;;;;:::i;:::-;;1208:10;1197:37;;;1220:6;1228:5;1197:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:2;8:100;;;99:1;94:3;90;84:5;80:1;75:3;71;64:6;52:2;49:1;45:3;40:15;;8:100;;;12:14;3:109;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1;8:100;33:3;30:1;27:2;8:100;;;99:1;94:3;90;84:5;80:1;75:3;71;64:6;52:2;49:1;45:3;40:15;;8:100;;;12:14;3:109;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1002:239:2;;:::o;1247:282::-;1344:20;1331:1;1314:6;1308:20;:24;1300:33;;;;;;;;1367:6;:18;1374:10;1367:18;;;;;;;;;;;;;;;1386:6;1367:26;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:2;51:6;36:153;;;182:3;176:5;171:3;164:6;98:2;93:3;89;82:19;;123:2;118:3;114;107:19;;148:2;143:3;139;132:19;;36:153;;;274:1;267:3;263:2;259:3;254;250;246;315:4;311:3;305;299:5;295:3;356:4;350:3;344:5;340:3;389:7;380;377:2;372:3;365:6;3:399;;;;;;;;;;;;;;;;;;;;;;;;1344:49:2;;1433:1;1417:5;1411:19;;;;;;;;;;;;;;;;:23;1403:32;;;;;;;;1453:6;:18;1460:10;1453:18;;;;;;;;;;;;;;;1472:6;1453:26;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:2;51:6;36:153;;;182:3;176:5;171:3;164:6;98:2;93:3;89;82:19;;123:2;118:3;114;107:19;;148:2;143:3;139;132:19;;36:153;;;274:1;267:3;263:2;259:3;254;250;246;315:4;311:3;305;299:5;295:3;356:4;350:3;344:5;340:3;389:7;380;377:2;372:3;365:6;3:399;;;;;;;;;;;;;;;;;;;;;;;;;1446:33:2;;;;:::i;:::-;1503:10;1490:32;;;1515:6;1490:32;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:2;8:100;;;99:1;94:3;90;84:5;80:1;75:3;71;64:6;52:2;49:1;45:3;40:15;;8:100;;;12:14;3:109;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1247:282:2;;:::o;836:160::-;907:1;899:10;;891:18;;;:4;:18;;;;;883:27;;;;;;;;921:32;942:10;921:7;:13;929:4;921:13;;;;;;;;;;;;;;;;;:20;;:32;;;;:::i;:::-;;978:10;964:25;;972:4;964:25;;;;;;;;;;;;;836:160;:::o;2009:183:0:-;2131:7;2161:4;:10;;:19;2172:7;2161:19;;;;;;;;;;;;;;;:24;;;;;;;;;;;;2154:31;;2009:183;;;;:::o;315:563::-;420:4;467:1;448:21;;:7;:21;;;;440:30;;;;;;;;506:1;485:23;;:4;:9;;;;;;;;;;;;:23;;;481:310;;;550:7;538:4;:9;;;:19;;;;;;;;;;;;;;;;;;481:310;;;579:23;588:4;594:7;579:8;:23::i;:::-;578:24;574:217;;;663:7;634:4;:10;;:21;645:4;:9;;;;;;;;;;;;634:21;;;;;;;;;;;;;;;:26;;;:36;;;;;;;;;;;;;;;;;;715:4;:9;;;;;;;;;;;;684:4;:10;;:19;695:7;684:19;;;;;;;;;;;;;;;:28;;;:40;;;;;;;;;;;;;;;;;;574:217;;;775:5;768:12;;;;574:217;481:310;813:7;801:4;:9;;;:19;;;;;;;;;;;;;;;;;;830;844:4;830:13;:19::i;:::-;867:4;860:11;;315:563;;;;;:::o;884:742::-;992:4;1053:17;1039:1;1020:21;;:7;:21;;;;1012:30;;;;;;;;1073:4;:10;;:19;1084:7;1073:19;;;;;;;;;;;;;;;1053:39;;1132:1;1107:27;;:4;:13;;;;;;;;;;;;:27;;;;1103:263;;;1201:4;:9;;;;;;;;;;;;1168:4;:10;;:25;1179:4;:13;;;;;;;;;;;;1168:25;;;;;;;;;;;;;;;:30;;;:42;;;;;;;;;;;;;;;;;;1103:263;;;1242:4;:9;;;;;;;;;;;;1231:20;;:7;:20;;;1227:139;;;1287:4;:9;;;;;;;;;;;;1275:4;:9;;;:21;;;;;;;;;;;;;;;;;;1227:139;;;1350:5;1343:12;;;;1227:139;1103:263;1401:1;1380:23;;:4;:9;;;;;;;;;;;;:23;;;;1376:156;;;1452:4;:13;;;;;;;;;;;;1419:4;:10;;:21;1430:4;:9;;;;;;;;;;;;1419:21;;;;;;;;;;;;;;;:30;;;:46;;;;;;;;;;;;;;;;;;1376:156;;;1508:4;:13;;;;;;;;;;;;1496:4;:9;;;:25;;;;;;;;;;;;;;;;;;1376:156;1542:19;1556:4;1542:13;:19::i;:::-;1578:4;:10;;:19;1589:7;1578:19;;;;;;;;;;;;;;;;1571:26;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1615:4;1608:11;;884:742;;;;;;:::o;2395:235::-;2518:4;2556;:9;;;;;;;;;;;;2545:20;;:7;:20;;;:78;;;;2621:1;2581:42;;:4;:10;;:19;2592:7;2581:19;;;;;;;;;;;;;;;:28;;;;;;;;;;;;:42;;;;2545:78;2538:85;;2395:235;;;;:::o;2672:124::-;2756:4;:10;;;2752:1;2739:4;:10;;;:14;:27;2732:35;;;;;;2777:4;:10;;;:12;;;;;;;;;;;;;2672:124;:::o;2802:111::-;2882:1;2869:4;:10;;;:14;2862:22;;;;;;2894:4;:10;;;:12;;;;;;;;;;;;;;2802:111;:::o;54:2317:2:-;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o",
+  "source":
+    "pragma solidity 0.4.18;\n\nimport \"./AddressSet.sol\";\n\n\ncontract SignHash {\n\n    //--- Definitions\n    using AddressSet for AddressSet.Data;\n\n    //--- Storage\n    // hash to signers\n    mapping (bytes32 => AddressSet.Data) private signers;\n\n    // signer to proofs (method to value)\n    mapping (address => mapping (string => string)) private proofs;\n\n    //--- Events\n    event Signed(bytes32 indexed hash, address indexed signer);\n    event Revoked(bytes32 indexed hash, address indexed signer);\n\n    event ProofAdded(address indexed signer, string method, string value);\n    event ProofRemoved(address indexed signer, string method);\n\n    //--- Public mutable functions\n    function sign(bytes32 hash) public {\n        require(hash != bytes32(0));\n\n        signers[hash].add(msg.sender);\n\n        Signed(hash, msg.sender);\n    }\n\n    function revoke(bytes32 hash) public {\n        require(hash != bytes32(0));\n\n        signers[hash].remove(msg.sender);\n\n        Revoked(hash, msg.sender);\n    }\n\n    function addProof(string method, string value) public {\n        require(bytes(method).length > 0);\n        require(bytes(value).length > 0);\n\n        proofs[msg.sender][method] = value;\n\n        ProofAdded(msg.sender, method, value);\n    }\n\n    function removeProof(string method) public {\n        require(bytes(method).length > 0);\n\n        string storage value = proofs[msg.sender][method];\n        require(bytes(value).length > 0);\n\n        delete proofs[msg.sender][method];\n\n        ProofRemoved(msg.sender, method);\n    }\n\n    //--- Public constant functions\n    function getSigners(bytes32 hash, uint256 maxCount)\n        public\n        view\n        returns (address[] result)\n    {\n        AddressSet.Data storage hashSigners = signers[hash];\n        if (hashSigners.count > 0) {\n            if (maxCount < hashSigners.count) {\n                result = new address[](maxCount);\n            } else {\n                result = new address[](hashSigners.count);\n            }\n\n            address current = hashSigners.head;\n            for (uint256 i = 0; i < result.length; i++) {\n                result[i] = current;\n                current = hashSigners.getNext(current);\n            }\n        }\n    }\n\n    function getProof(address signer, string method)\n        public\n        view\n        returns (string)\n    {\n        return proofs[signer][method];\n    }\n}\n",
+  "sourcePath":
+    "/home/biern/projects/signhash/signhash-contracts/contracts/SignHash.sol",
+  "ast": {
+    "attributes": {
+      "absolutePath":
+        "/home/biern/projects/signhash/signhash-contracts/contracts/SignHash.sol",
+      "exportedSymbols": {
+        "SignHash": [677]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": ["solidity", "0.4", ".18", ".18"]
+        },
+        "id": 395,
+        "name": "PragmaDirective",
+        "src": "0:23:2"
+      },
+      {
+        "attributes": {
+          "SourceUnit": 336,
+          "absolutePath":
+            "/home/biern/projects/signhash/signhash-contracts/contracts/AddressSet.sol",
+          "file": "./AddressSet.sol",
+          "scope": 678,
+          "symbolAliases": [null],
+          "unitAlias": ""
+        },
+        "id": 396,
+        "name": "ImportDirective",
+        "src": "25:26:2"
+      },
+      {
+        "attributes": {
+          "baseContracts": [null],
+          "contractDependencies": [null],
+          "contractKind": "contract",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [677],
+          "name": "SignHash",
+          "scope": 678
+        },
+        "children": [
+          {
+            "children": [
+              {
+                "attributes": {
+                  "contractScope": null,
+                  "name": "AddressSet",
+                  "referencedDeclaration": 335,
+                  "type": "library AddressSet"
+                },
+                "id": 397,
+                "name": "UserDefinedTypeName",
+                "src": "107:10:2"
+              },
+              {
+                "attributes": {
+                  "contractScope": null,
+                  "name": "AddressSet.Data",
+                  "referencedDeclaration": 17,
+                  "type": "struct AddressSet.Data storage pointer"
+                },
+                "id": 398,
+                "name": "UserDefinedTypeName",
+                "src": "122:15:2"
+              }
+            ],
+            "id": 399,
+            "name": "UsingForDirective",
+            "src": "101:37:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "signers",
+              "scope": 677,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "mapping(bytes32 => struct AddressSet.Data storage ref)",
+              "value": null,
+              "visibility": "private"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "type":
+                    "mapping(bytes32 => struct AddressSet.Data storage ref)"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "bytes32",
+                      "type": "bytes32"
+                    },
+                    "id": 400,
+                    "name": "ElementaryTypeName",
+                    "src": "194:7:2"
+                  },
+                  {
+                    "attributes": {
+                      "contractScope": null,
+                      "name": "AddressSet.Data",
+                      "referencedDeclaration": 17,
+                      "type": "struct AddressSet.Data storage pointer"
+                    },
+                    "id": 401,
+                    "name": "UserDefinedTypeName",
+                    "src": "205:15:2"
+                  }
+                ],
+                "id": 402,
+                "name": "Mapping",
+                "src": "185:36:2"
+              }
+            ],
+            "id": 403,
+            "name": "VariableDeclaration",
+            "src": "185:52:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "proofs",
+              "scope": 677,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type":
+                "mapping(address => mapping(string memory => string storage ref))",
+              "value": null,
+              "visibility": "private"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "type":
+                    "mapping(address => mapping(string memory => string storage ref))"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 404,
+                    "name": "ElementaryTypeName",
+                    "src": "295:7:2"
+                  },
+                  {
+                    "attributes": {
+                      "type": "mapping(string memory => string storage ref)"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 405,
+                        "name": "ElementaryTypeName",
+                        "src": "315:6:2"
+                      },
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 406,
+                        "name": "ElementaryTypeName",
+                        "src": "325:6:2"
+                      }
+                    ],
+                    "id": 407,
+                    "name": "Mapping",
+                    "src": "306:26:2"
+                  }
+                ],
+                "id": 408,
+                "name": "Mapping",
+                "src": "286:47:2"
+              }
+            ],
+            "id": 409,
+            "name": "VariableDeclaration",
+            "src": "286:62:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": true,
+              "modifiers": [null],
+              "name": "Signed",
+              "payable": false,
+              "scope": 681,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public",
+              "anonymous": false
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "hash",
+                      "scope": 415,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bytes32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bytes32",
+                          "type": "bytes32"
+                        },
+                        "id": 410,
+                        "name": "ElementaryTypeName",
+                        "src": "385:7:2"
+                      }
+                    ],
+                    "id": 411,
+                    "name": "VariableDeclaration",
+                    "src": "385:20:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "signer",
+                      "scope": 415,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 412,
+                        "name": "ElementaryTypeName",
+                        "src": "407:7:2"
+                      }
+                    ],
+                    "id": 413,
+                    "name": "VariableDeclaration",
+                    "src": "407:22:2"
+                  }
+                ],
+                "id": 414,
+                "name": "ParameterList",
+                "src": "384:46:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 411,
+                "name": "ParameterList",
+                "src": "408:0:2"
+              },
+              {
+                "attributes": {
+                  "statements": [null]
+                },
+                "children": [],
+                "id": 412,
+                "name": "Block",
+                "src": "408:2:2"
+              }
+            ],
+            "id": 415,
+            "name": "EventDefinition",
+            "src": "372:59:2"
+          },
+          {
+            "attributes": {
+              "anonymous": false,
+              "name": "Revoked"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "hash",
+                      "scope": 421,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bytes32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bytes32",
+                          "type": "bytes32"
+                        },
+                        "id": 416,
+                        "name": "ElementaryTypeName",
+                        "src": "450:7:2"
+                      }
+                    ],
+                    "id": 417,
+                    "name": "VariableDeclaration",
+                    "src": "450:20:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "signer",
+                      "scope": 421,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 418,
+                        "name": "ElementaryTypeName",
+                        "src": "472:7:2"
+                      }
+                    ],
+                    "id": 419,
+                    "name": "VariableDeclaration",
+                    "src": "472:22:2"
+                  }
+                ],
+                "id": 420,
+                "name": "ParameterList",
+                "src": "449:46:2"
+              }
+            ],
+            "id": 421,
+            "name": "EventDefinition",
+            "src": "436:60:2"
+          },
+          {
+            "attributes": {
+              "anonymous": false,
+              "name": "ProofAdded"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "signer",
+                      "scope": 429,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 422,
+                        "name": "ElementaryTypeName",
+                        "src": "519:7:2"
+                      }
+                    ],
+                    "id": 423,
+                    "name": "VariableDeclaration",
+                    "src": "519:22:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "method",
+                      "scope": 429,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 424,
+                        "name": "ElementaryTypeName",
+                        "src": "543:6:2"
+                      }
+                    ],
+                    "id": 425,
+                    "name": "VariableDeclaration",
+                    "src": "543:13:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "value",
+                      "scope": 429,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 426,
+                        "name": "ElementaryTypeName",
+                        "src": "558:6:2"
+                      }
+                    ],
+                    "id": 427,
+                    "name": "VariableDeclaration",
+                    "src": "558:12:2"
+                  }
+                ],
+                "id": 428,
+                "name": "ParameterList",
+                "src": "518:53:2"
+              }
+            ],
+            "id": 429,
+            "name": "EventDefinition",
+            "src": "502:70:2"
+          },
+          {
+            "attributes": {
+              "anonymous": false,
+              "name": "ProofRemoved"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "signer",
+                      "scope": 435,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 430,
+                        "name": "ElementaryTypeName",
+                        "src": "596:7:2"
+                      }
+                    ],
+                    "id": 431,
+                    "name": "VariableDeclaration",
+                    "src": "596:22:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "method",
+                      "scope": 435,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 432,
+                        "name": "ElementaryTypeName",
+                        "src": "620:6:2"
+                      }
+                    ],
+                    "id": 433,
+                    "name": "VariableDeclaration",
+                    "src": "620:13:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "value",
+                      "scope": 433,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 430,
+                        "name": "ElementaryTypeName",
+                        "src": "620:6:2"
+                      }
+                    ],
+                    "id": 431,
+                    "name": "VariableDeclaration",
+                    "src": "620:12:2"
+                  }
+                ],
+                "id": 434,
+                "name": "ParameterList",
+                "src": "595:39:2"
+              }
+            ],
+            "id": 435,
+            "name": "EventDefinition",
+            "src": "577:58:2"
+          },
+          {
+            "attributes": {
+              "anonymous": false,
+              "name": "sign",
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": true,
+                      "name": "hash",
+                      "scope": 463,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bytes32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bytes32",
+                          "type": "bytes32"
+                        },
+                        "id": 436,
+                        "name": "ElementaryTypeName",
+                        "src": "690:7:2"
+                      }
+                    ],
+                    "id": 437,
+                    "name": "VariableDeclaration",
+                    "src": "690:12:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "indexed": false,
+                      "name": "method",
+                      "scope": 439,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 436,
+                        "name": "ElementaryTypeName",
+                        "src": "682:6:2"
+                      }
+                    ],
+                    "id": 437,
+                    "name": "VariableDeclaration",
+                    "src": "682:13:2"
+                  }
+                ],
+                "id": 438,
+                "name": "ParameterList",
+                "src": "689:14:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 439,
+                "name": "ParameterList",
+                "src": "711:0:2"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 440,
+                            "name": "Identifier",
+                            "src": "721:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_bytes32",
+                                "typeString": "bytes32"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 437,
+                                  "type": "bytes32",
+                                  "value": "hash"
+                                },
+                                "id": 441,
+                                "name": "Identifier",
+                                "src": "729:4:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "bytes32",
+                                  "type_conversion": true
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(bytes32)",
+                                      "value": "bytes32"
+                                    },
+                                    "id": 442,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "737:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 443,
+                                    "name": "Literal",
+                                    "src": "745:1:2"
+                                  }
+                                ],
+                                "id": 444,
+                                "name": "FunctionCall",
+                                "src": "737:10:2"
+                              }
+                            ],
+                            "id": 445,
+                            "name": "BinaryOperation",
+                            "src": "729:18:2"
+                          }
+                        ],
+                        "id": 446,
+                        "name": "FunctionCall",
+                        "src": "721:27:2"
+                      }
+                    ],
+                    "id": 447,
+                    "name": "ExpressionStatement",
+                    "src": "721:27:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "bool",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "add",
+                              "referencedDeclaration": 91,
+                              "type":
+                                "function (struct AddressSet.Data storage pointer,address) returns (bool)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "struct AddressSet.Data storage ref"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 403,
+                                      "type":
+                                        "mapping(bytes32 => struct AddressSet.Data storage ref)",
+                                      "value": "signers"
+                                    },
+                                    "id": 448,
+                                    "name": "Identifier",
+                                    "src": "759:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 437,
+                                      "type": "bytes32",
+                                      "value": "hash"
+                                    },
+                                    "id": 449,
+                                    "name": "Identifier",
+                                    "src": "767:4:2"
+                                  }
+                                ],
+                                "id": 450,
+                                "name": "IndexAccess",
+                                "src": "759:13:2"
+                              }
+                            ],
+                            "id": 451,
+                            "name": "MemberAccess",
+                            "src": "759:17:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 452,
+                                "name": "Identifier",
+                                "src": "777:3:2"
+                              }
+                            ],
+                            "id": 453,
+                            "name": "MemberAccess",
+                            "src": "777:10:2"
+                          }
+                        ],
+                        "id": 454,
+                        "name": "FunctionCall",
+                        "src": "759:29:2"
+                      }
+                    ],
+                    "id": 455,
+                    "name": "ExpressionStatement",
+                    "src": "759:29:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bytes32",
+                                  "typeString": "bytes32"
+                                },
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 415,
+                              "type": "function (bytes32,address)",
+                              "value": "Signed"
+                            },
+                            "id": 456,
+                            "name": "Identifier",
+                            "src": "799:6:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 437,
+                              "type": "bytes32",
+                              "value": "hash"
+                            },
+                            "id": 457,
+                            "name": "Identifier",
+                            "src": "806:4:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 458,
+                                "name": "Identifier",
+                                "src": "812:3:2"
+                              }
+                            ],
+                            "id": 459,
+                            "name": "MemberAccess",
+                            "src": "812:10:2"
+                          }
+                        ],
+                        "id": 460,
+                        "name": "FunctionCall",
+                        "src": "799:24:2"
+                      }
+                    ],
+                    "id": 461,
+                    "name": "ExpressionStatement",
+                    "src": "799:24:2"
+                  }
+                ],
+                "id": 462,
+                "name": "Block",
+                "src": "711:119:2"
+              }
+            ],
+            "id": 463,
+            "name": "FunctionDefinition",
+            "src": "676:154:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "revoke",
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "hash",
+                      "scope": 491,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bytes32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bytes32",
+                          "type": "bytes32"
+                        },
+                        "id": 464,
+                        "name": "ElementaryTypeName",
+                        "src": "852:7:2"
+                      }
+                    ],
+                    "id": 465,
+                    "name": "VariableDeclaration",
+                    "src": "852:12:2"
+                  }
+                ],
+                "id": 466,
+                "name": "ParameterList",
+                "src": "851:14:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 467,
+                "name": "ParameterList",
+                "src": "873:0:2"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 468,
+                            "name": "Identifier",
+                            "src": "883:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_bytes32",
+                                "typeString": "bytes32"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "!=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 465,
+                                  "type": "bytes32",
+                                  "value": "hash"
+                                },
+                                "id": 469,
+                                "name": "Identifier",
+                                "src": "891:4:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "bytes32",
+                                  "type_conversion": true
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(bytes32)",
+                                      "value": "bytes32"
+                                    },
+                                    "id": 470,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "899:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 471,
+                                    "name": "Literal",
+                                    "src": "907:1:2"
+                                  }
+                                ],
+                                "id": 472,
+                                "name": "FunctionCall",
+                                "src": "899:10:2"
+                              }
+                            ],
+                            "id": 473,
+                            "name": "BinaryOperation",
+                            "src": "891:18:2"
+                          }
+                        ],
+                        "id": 474,
+                        "name": "FunctionCall",
+                        "src": "883:27:2"
+                      }
+                    ],
+                    "id": 475,
+                    "name": "ExpressionStatement",
+                    "src": "883:27:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "bool",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "remove",
+                              "referencedDeclaration": 190,
+                              "type":
+                                "function (struct AddressSet.Data storage pointer,address) returns (bool)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "struct AddressSet.Data storage ref"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 403,
+                                      "type":
+                                        "mapping(bytes32 => struct AddressSet.Data storage ref)",
+                                      "value": "signers"
+                                    },
+                                    "id": 476,
+                                    "name": "Identifier",
+                                    "src": "921:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 465,
+                                      "type": "bytes32",
+                                      "value": "hash"
+                                    },
+                                    "id": 477,
+                                    "name": "Identifier",
+                                    "src": "929:4:2"
+                                  }
+                                ],
+                                "id": 478,
+                                "name": "IndexAccess",
+                                "src": "921:13:2"
+                              }
+                            ],
+                            "id": 479,
+                            "name": "MemberAccess",
+                            "src": "921:20:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 480,
+                                "name": "Identifier",
+                                "src": "942:3:2"
+                              }
+                            ],
+                            "id": 481,
+                            "name": "MemberAccess",
+                            "src": "942:10:2"
+                          }
+                        ],
+                        "id": 482,
+                        "name": "FunctionCall",
+                        "src": "921:32:2"
+                      }
+                    ],
+                    "id": 483,
+                    "name": "ExpressionStatement",
+                    "src": "921:32:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bytes32",
+                                  "typeString": "bytes32"
+                                },
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 421,
+                              "type": "function (bytes32,address)",
+                              "value": "Revoked"
+                            },
+                            "id": 484,
+                            "name": "Identifier",
+                            "src": "964:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 465,
+                              "type": "bytes32",
+                              "value": "hash"
+                            },
+                            "id": 485,
+                            "name": "Identifier",
+                            "src": "972:4:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 486,
+                                "name": "Identifier",
+                                "src": "978:3:2"
+                              }
+                            ],
+                            "id": 487,
+                            "name": "MemberAccess",
+                            "src": "978:10:2"
+                          }
+                        ],
+                        "id": 488,
+                        "name": "FunctionCall",
+                        "src": "964:25:2"
+                      }
+                    ],
+                    "id": 489,
+                    "name": "ExpressionStatement",
+                    "src": "964:25:2"
+                  }
+                ],
+                "id": 490,
+                "name": "Block",
+                "src": "873:123:2"
+              }
+            ],
+            "id": 491,
+            "name": "FunctionDefinition",
+            "src": "836:160:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "addProof",
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "method",
+                      "scope": 533,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 492,
+                        "name": "ElementaryTypeName",
+                        "src": "1020:6:2"
+                      }
+                    ],
+                    "id": 493,
+                    "name": "VariableDeclaration",
+                    "src": "1020:13:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "value",
+                      "scope": 533,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 494,
+                        "name": "ElementaryTypeName",
+                        "src": "1035:6:2"
+                      }
+                    ],
+                    "id": 495,
+                    "name": "VariableDeclaration",
+                    "src": "1035:12:2"
+                  }
+                ],
+                "id": 496,
+                "name": "ParameterList",
+                "src": "1019:29:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 497,
+                "name": "ParameterList",
+                "src": "1056:0:2"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 498,
+                            "name": "Identifier",
+                            "src": "1066:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": null,
+                                  "type": "uint256",
+                                  "value": "hash",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length"
+                                },
+                                "id": 502,
+                                "name": "MemberAccess",
+                                "src": "1074:20:2",
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes memory",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_memory_ptr",
+                                              "typeString": "string memory"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 499,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1074:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 493,
+                                          "type": "string memory",
+                                          "value": "method"
+                                        },
+                                        "id": 500,
+                                        "name": "Identifier",
+                                        "src": "1080:6:2"
+                                      }
+                                    ],
+                                    "id": 501,
+                                    "name": "FunctionCall",
+                                    "src": "1074:13:2"
+                                  }
+                                ]
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "isStructConstructorCall": false,
+                                  "lValueRequested": false,
+                                  "names": [null],
+                                  "type": "int_const 0",
+                                  "type_conversion": true,
+                                  "hexvalue": "30",
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "value": "0"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": [
+                                        {
+                                          "typeIdentifier": "t_rational_0_by_1",
+                                          "typeString": "int_const 0"
+                                        }
+                                      ],
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "type": "type(bytes32)",
+                                      "value": "bytes32"
+                                    },
+                                    "id": 474,
+                                    "name": "ElementaryTypeNameExpression",
+                                    "src": "962:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 475,
+                                    "name": "Literal",
+                                    "src": "970:1:2"
+                                  }
+                                ],
+                                "id": 503,
+                                "name": "Literal",
+                                "src": "1097:1:2"
+                              }
+                            ],
+                            "id": 504,
+                            "name": "BinaryOperation",
+                            "src": "1074:24:2"
+                          }
+                        ],
+                        "id": 505,
+                        "name": "FunctionCall",
+                        "src": "1066:33:2"
+                      }
+                    ],
+                    "id": 506,
+                    "name": "ExpressionStatement",
+                    "src": "1066:33:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "remove",
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "overloadedDeclarations": [null],
+                              "value": "require"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "struct AddressSet.Data storage ref"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 403,
+                                      "type":
+                                        "mapping(bytes32 => struct AddressSet.Data storage ref)",
+                                      "value": "signers"
+                                    },
+                                    "id": 480,
+                                    "name": "Identifier",
+                                    "src": "984:7:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 469,
+                                      "type": "bytes32",
+                                      "value": "hash"
+                                    },
+                                    "id": 481,
+                                    "name": "Identifier",
+                                    "src": "992:4:2"
+                                  }
+                                ],
+                                "id": 482,
+                                "name": "IndexAccess",
+                                "src": "984:13:2"
+                              }
+                            ],
+                            "id": 507,
+                            "name": "Identifier",
+                            "src": "1109:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "bool",
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "operator": ">"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": null,
+                                  "type": "uint256",
+                                  "value": "msg",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length"
+                                },
+                                "id": 511,
+                                "name": "MemberAccess",
+                                "src": "1117:19:2",
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes memory",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_memory_ptr",
+                                              "typeString": "string memory"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 508,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1117:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 495,
+                                          "type": "string memory",
+                                          "value": "value"
+                                        },
+                                        "id": 509,
+                                        "name": "Identifier",
+                                        "src": "1123:5:2"
+                                      }
+                                    ],
+                                    "id": 510,
+                                    "name": "FunctionCall",
+                                    "src": "1117:12:2"
+                                  }
+                                ]
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 512,
+                                "name": "Literal",
+                                "src": "1139:1:2"
+                              }
+                            ],
+                            "id": 513,
+                            "name": "BinaryOperation",
+                            "src": "1117:23:2"
+                          }
+                        ],
+                        "id": 514,
+                        "name": "FunctionCall",
+                        "src": "1109:32:2"
+                      }
+                    ],
+                    "id": 515,
+                    "name": "ExpressionStatement",
+                    "src": "1109:32:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "string storage ref",
+                          "type_conversion": false,
+                          "operator": "="
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 425,
+                              "type": "string storage ref",
+                              "value": "Revoked",
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true
+                            },
+                            "id": 521,
+                            "name": "IndexAccess",
+                            "src": "1152:26:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type":
+                                    "mapping(string memory => string storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 409,
+                                      "type":
+                                        "mapping(address => mapping(string memory => string storage ref))",
+                                      "value": "proofs"
+                                    },
+                                    "id": 516,
+                                    "name": "Identifier",
+                                    "src": "1152:6:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "sender",
+                                      "referencedDeclaration": null,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 689,
+                                          "type": "msg",
+                                          "value": "msg"
+                                        },
+                                        "id": 517,
+                                        "name": "Identifier",
+                                        "src": "1159:3:2"
+                                      }
+                                    ],
+                                    "id": 518,
+                                    "name": "MemberAccess",
+                                    "src": "1159:10:2"
+                                  }
+                                ],
+                                "id": 520,
+                                "name": "IndexAccess",
+                                "src": "1152:18:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 493,
+                                  "type": "string memory",
+                                  "value": "method"
+                                },
+                                "id": 519,
+                                "name": "Identifier",
+                                "src": "1171:6:2"
+                              }
+                            ]
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 495,
+                              "type": "string memory",
+                              "value": "value"
+                            },
+                            "id": 522,
+                            "name": "Identifier",
+                            "src": "1181:5:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 693,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 490,
+                                "name": "Identifier",
+                                "src": "1041:3:2"
+                              }
+                            ],
+                            "id": 491,
+                            "name": "MemberAccess",
+                            "src": "1041:10:2"
+                          }
+                        ],
+                        "id": 523,
+                        "name": "Assignment",
+                        "src": "1152:34:2"
+                      }
+                    ],
+                    "id": 524,
+                    "name": "ExpressionStatement",
+                    "src": "1152:34:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                },
+                                {
+                                  "typeIdentifier": "t_string_memory_ptr",
+                                  "typeString": "string memory"
+                                },
+                                {
+                                  "typeIdentifier": "t_string_memory_ptr",
+                                  "typeString": "string memory"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 429,
+                              "type":
+                                "function (address,string memory,string memory)",
+                              "value": "ProofAdded"
+                            },
+                            "id": 525,
+                            "name": "Identifier",
+                            "src": "1197:10:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 526,
+                                "name": "Identifier",
+                                "src": "1208:3:2"
+                              }
+                            ],
+                            "id": 527,
+                            "name": "MemberAccess",
+                            "src": "1208:10:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 493,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 528,
+                            "name": "Identifier",
+                            "src": "1220:6:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 495,
+                              "type": "string memory",
+                              "value": "value"
+                            },
+                            "id": 529,
+                            "name": "Identifier",
+                            "src": "1228:5:2"
+                          }
+                        ],
+                        "id": 530,
+                        "name": "FunctionCall",
+                        "src": "1197:37:2"
+                      }
+                    ],
+                    "id": 531,
+                    "name": "ExpressionStatement",
+                    "src": "1197:37:2"
+                  }
+                ],
+                "id": 532,
+                "name": "Block",
+                "src": "1056:185:2"
+              }
+            ],
+            "id": 533,
+            "name": "FunctionDefinition",
+            "src": "1002:239:2"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "removeProof",
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "method",
+                      "scope": 580,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 534,
+                        "name": "ElementaryTypeName",
+                        "src": "1268:6:2"
+                      }
+                    ],
+                    "id": 535,
+                    "name": "VariableDeclaration",
+                    "src": "1268:13:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "value",
+                      "scope": 537,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 498,
+                        "name": "ElementaryTypeName",
+                        "src": "1098:6:2"
+                      }
+                    ],
+                    "id": 499,
+                    "name": "VariableDeclaration",
+                    "src": "1098:12:2"
+                  }
+                ],
+                "id": 536,
+                "name": "ParameterList",
+                "src": "1267:15:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [],
+                "id": 537,
+                "name": "ParameterList",
+                "src": "1290:0:2"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 538,
+                            "name": "Identifier",
+                            "src": "1300:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length",
+                                  "referencedDeclaration": null,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes memory",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_memory_ptr",
+                                              "typeString": "string memory"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 539,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1308:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 535,
+                                          "type": "string memory",
+                                          "value": "method"
+                                        },
+                                        "id": 540,
+                                        "name": "Identifier",
+                                        "src": "1314:6:2"
+                                      }
+                                    ],
+                                    "id": 541,
+                                    "name": "FunctionCall",
+                                    "src": "1308:13:2"
+                                  }
+                                ],
+                                "id": 542,
+                                "name": "MemberAccess",
+                                "src": "1308:20:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 543,
+                                "name": "Literal",
+                                "src": "1331:1:2"
+                              }
+                            ],
+                            "id": 544,
+                            "name": "BinaryOperation",
+                            "src": "1308:24:2"
+                          }
+                        ],
+                        "id": 545,
+                        "name": "FunctionCall",
+                        "src": "1300:33:2"
+                      }
+                    ],
+                    "id": 546,
+                    "name": "ExpressionStatement",
+                    "src": "1300:33:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "string storage pointer",
+                          "type_conversion": false,
+                          "constant": false,
+                          "name": "value",
+                          "scope": 580,
+                          "stateVariable": false,
+                          "storageLocation": "storage",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 696,
+                              "type": "string storage pointer",
+                              "value": "require",
+                              "name": "string"
+                            },
+                            "id": 547,
+                            "name": "ElementaryTypeName",
+                            "src": "1344:6:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length",
+                                  "referencedDeclaration": null,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes memory",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_memory_ptr",
+                                              "typeString": "string memory"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 512,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1180:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 499,
+                                          "type": "string memory",
+                                          "value": "value"
+                                        },
+                                        "id": 513,
+                                        "name": "Identifier",
+                                        "src": "1186:5:2"
+                                      }
+                                    ],
+                                    "id": 514,
+                                    "name": "FunctionCall",
+                                    "src": "1180:12:2"
+                                  }
+                                ],
+                                "id": 515,
+                                "name": "MemberAccess",
+                                "src": "1180:19:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 516,
+                                "name": "Literal",
+                                "src": "1202:1:2"
+                              }
+                            ],
+                            "id": 517,
+                            "name": "BinaryOperation",
+                            "src": "1180:23:2"
+                          }
+                        ],
+                        "id": 548,
+                        "name": "VariableDeclaration",
+                        "src": "1344:20:2"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "string storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "type":
+                                "mapping(string memory => string storage ref)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 409,
+                                  "type":
+                                    "mapping(address => mapping(string memory => string storage ref))",
+                                  "value": "proofs"
+                                },
+                                "id": 549,
+                                "name": "Identifier",
+                                "src": "1367:6:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "sender",
+                                  "referencedDeclaration": null,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 689,
+                                      "type": "msg",
+                                      "value": "msg"
+                                    },
+                                    "id": 550,
+                                    "name": "Identifier",
+                                    "src": "1374:3:2"
+                                  }
+                                ],
+                                "id": 551,
+                                "name": "MemberAccess",
+                                "src": "1374:10:2"
+                              }
+                            ],
+                            "id": 552,
+                            "name": "IndexAccess",
+                            "src": "1367:18:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 535,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 553,
+                            "name": "Identifier",
+                            "src": "1386:6:2"
+                          }
+                        ],
+                        "id": 554,
+                        "name": "IndexAccess",
+                        "src": "1367:26:2"
+                      }
+                    ],
+                    "id": 555,
+                    "name": "VariableDeclarationStatement",
+                    "src": "1344:49:2",
+                    "attributes": {
+                      "assignments": [548]
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "tuple()",
+                          "isStructConstructorCall": false,
+                          "names": [null],
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "type": "function (bool) pure",
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 692,
+                              "value": "require"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type":
+                                    "mapping(string memory => string storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 409,
+                                      "type":
+                                        "mapping(address => mapping(string memory => string storage ref))",
+                                      "value": "proofs"
+                                    },
+                                    "id": 520,
+                                    "name": "Identifier",
+                                    "src": "1215:6:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "sender",
+                                      "referencedDeclaration": null,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 693,
+                                          "type": "msg",
+                                          "value": "msg"
+                                        },
+                                        "id": 521,
+                                        "name": "Identifier",
+                                        "src": "1222:3:2"
+                                      }
+                                    ],
+                                    "id": 522,
+                                    "name": "MemberAccess",
+                                    "src": "1222:10:2"
+                                  }
+                                ],
+                                "id": 524,
+                                "name": "IndexAccess",
+                                "src": "1215:18:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 497,
+                                  "type": "string memory",
+                                  "value": "method"
+                                },
+                                "id": 523,
+                                "name": "Identifier",
+                                "src": "1234:6:2"
+                              }
+                            ],
+                            "id": 556,
+                            "name": "Identifier",
+                            "src": "1403:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 499,
+                              "type": "bool",
+                              "value": "value",
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">"
+                            },
+                            "id": 562,
+                            "name": "BinaryOperation",
+                            "src": "1411:23:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length",
+                                  "referencedDeclaration": null,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes storage ref",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_storage_ptr",
+                                              "typeString":
+                                                "string storage pointer"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 557,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1411:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 548,
+                                          "type": "string storage pointer",
+                                          "value": "value"
+                                        },
+                                        "id": 558,
+                                        "name": "Identifier",
+                                        "src": "1417:5:2"
+                                      }
+                                    ],
+                                    "id": 559,
+                                    "name": "FunctionCall",
+                                    "src": "1411:12:2"
+                                  }
+                                ],
+                                "id": 560,
+                                "name": "MemberAccess",
+                                "src": "1411:19:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 561,
+                                "name": "Literal",
+                                "src": "1433:1:2"
+                              }
+                            ]
+                          }
+                        ],
+                        "id": 563,
+                        "name": "FunctionCall",
+                        "src": "1403:32:2"
+                      }
+                    ],
+                    "id": 564,
+                    "name": "ExpressionStatement",
+                    "src": "1403:32:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false,
+                          "operator": "delete",
+                          "prefix": true
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 433,
+                              "type": "string storage ref",
+                              "value": "ProofAdded",
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true
+                            },
+                            "id": 570,
+                            "name": "IndexAccess",
+                            "src": "1453:26:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type":
+                                    "mapping(string memory => string storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 409,
+                                      "type":
+                                        "mapping(address => mapping(string memory => string storage ref))",
+                                      "value": "proofs"
+                                    },
+                                    "id": 565,
+                                    "name": "Identifier",
+                                    "src": "1453:6:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "sender",
+                                      "referencedDeclaration": null,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 689,
+                                          "type": "msg",
+                                          "value": "msg"
+                                        },
+                                        "id": 566,
+                                        "name": "Identifier",
+                                        "src": "1460:3:2"
+                                      }
+                                    ],
+                                    "id": 567,
+                                    "name": "MemberAccess",
+                                    "src": "1460:10:2"
+                                  }
+                                ],
+                                "id": 568,
+                                "name": "IndexAccess",
+                                "src": "1453:18:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 535,
+                                  "type": "string memory",
+                                  "value": "method"
+                                },
+                                "id": 569,
+                                "name": "Identifier",
+                                "src": "1472:6:2"
+                              }
+                            ]
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 693,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 530,
+                                "name": "Identifier",
+                                "src": "1271:3:2"
+                              }
+                            ],
+                            "id": 531,
+                            "name": "MemberAccess",
+                            "src": "1271:10:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 497,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 532,
+                            "name": "Identifier",
+                            "src": "1283:6:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 499,
+                              "type": "string memory",
+                              "value": "value"
+                            },
+                            "id": 533,
+                            "name": "Identifier",
+                            "src": "1291:5:2"
+                          }
+                        ],
+                        "id": 571,
+                        "name": "UnaryOperation",
+                        "src": "1446:33:2"
+                      }
+                    ],
+                    "id": 572,
+                    "name": "ExpressionStatement",
+                    "src": "1446:33:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                },
+                                {
+                                  "typeIdentifier": "t_string_memory_ptr",
+                                  "typeString": "string memory"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 435,
+                              "type": "function (address,string memory)",
+                              "value": "ProofRemoved"
+                            },
+                            "id": 573,
+                            "name": "Identifier",
+                            "src": "1490:12:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 689,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 574,
+                                "name": "Identifier",
+                                "src": "1503:3:2"
+                              }
+                            ],
+                            "id": 575,
+                            "name": "MemberAccess",
+                            "src": "1503:10:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 535,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 576,
+                            "name": "Identifier",
+                            "src": "1515:6:2"
+                          }
+                        ],
+                        "id": 577,
+                        "name": "FunctionCall",
+                        "src": "1490:32:2"
+                      }
+                    ],
+                    "id": 578,
+                    "name": "ExpressionStatement",
+                    "src": "1490:32:2"
+                  }
+                ],
+                "id": 579,
+                "name": "Block",
+                "src": "1290:239:2"
+              }
+            ],
+            "id": 580,
+            "name": "FunctionDefinition",
+            "src": "1247:282:2"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "getSigners",
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "hash",
+                      "scope": 660,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "bytes32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "bytes32",
+                          "type": "bytes32"
+                        },
+                        "id": 581,
+                        "name": "ElementaryTypeName",
+                        "src": "1591:7:2"
+                      }
+                    ],
+                    "id": 582,
+                    "name": "VariableDeclaration",
+                    "src": "1591:12:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "maxCount",
+                      "scope": 660,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint256",
+                          "type": "uint256"
+                        },
+                        "id": 583,
+                        "name": "ElementaryTypeName",
+                        "src": "1605:7:2"
+                      }
+                    ],
+                    "id": 584,
+                    "name": "VariableDeclaration",
+                    "src": "1605:16:2"
+                  }
+                ],
+                "id": 585,
+                "name": "ParameterList",
+                "src": "1590:32:2"
+              },
+              {
+                "attributes": {
+                  "parameters": [null]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "result",
+                      "scope": 660,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address[] memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "length": null,
+                          "type": "address[] storage pointer"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "name": "address",
+                              "type": "address"
+                            },
+                            "id": 586,
+                            "name": "ElementaryTypeName",
+                            "src": "1668:7:2"
+                          }
+                        ],
+                        "id": 587,
+                        "name": "ArrayTypeName",
+                        "src": "1668:9:2"
+                      }
+                    ],
+                    "id": 588,
+                    "name": "VariableDeclaration",
+                    "src": "1668:16:2"
+                  }
+                ],
+                "id": 589,
+                "name": "ParameterList",
+                "src": "1667:18:2"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "struct AddressSet.Data storage pointer",
+                          "type_conversion": false,
+                          "constant": false,
+                          "name": "hashSigners",
+                          "scope": 660,
+                          "stateVariable": false,
+                          "storageLocation": "storage",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 17,
+                              "type": "struct AddressSet.Data storage pointer",
+                              "value": "require",
+                              "contractScope": null,
+                              "name": "AddressSet.Data"
+                            },
+                            "id": 592,
+                            "name": "UserDefinedTypeName",
+                            "src": "1700:15:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length",
+                                  "referencedDeclaration": null,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes memory",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_memory_ptr",
+                                              "typeString": "string memory"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 543,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1371:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 539,
+                                          "type": "string memory",
+                                          "value": "method"
+                                        },
+                                        "id": 544,
+                                        "name": "Identifier",
+                                        "src": "1377:6:2"
+                                      }
+                                    ],
+                                    "id": 545,
+                                    "name": "FunctionCall",
+                                    "src": "1371:13:2"
+                                  }
+                                ],
+                                "id": 546,
+                                "name": "MemberAccess",
+                                "src": "1371:20:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 547,
+                                "name": "Literal",
+                                "src": "1394:1:2"
+                              }
+                            ],
+                            "id": 548,
+                            "name": "BinaryOperation",
+                            "src": "1371:24:2"
+                          }
+                        ],
+                        "id": 593,
+                        "name": "VariableDeclaration",
+                        "src": "1700:35:2"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "struct AddressSet.Data storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 403,
+                              "type":
+                                "mapping(bytes32 => struct AddressSet.Data storage ref)",
+                              "value": "signers"
+                            },
+                            "id": 594,
+                            "name": "Identifier",
+                            "src": "1738:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 582,
+                              "type": "bytes32",
+                              "value": "hash"
+                            },
+                            "id": 595,
+                            "name": "Identifier",
+                            "src": "1746:4:2"
+                          }
+                        ],
+                        "id": 596,
+                        "name": "IndexAccess",
+                        "src": "1738:13:2"
+                      }
+                    ],
+                    "id": 597,
+                    "name": "VariableDeclarationStatement",
+                    "src": "1700:51:2",
+                    "attributes": {
+                      "assignments": [593]
+                    }
+                  },
+                  {
+                    "attributes": {
+                      "assignments": [552],
+                      "falseBody": null
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "value",
+                          "scope": 584,
+                          "stateVariable": false,
+                          "storageLocation": "storage",
+                          "type": "bool",
+                          "value": null,
+                          "visibility": "internal",
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": ">"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "name": "string",
+                              "type": "uint256",
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "count",
+                              "referencedDeclaration": 12
+                            },
+                            "id": 599,
+                            "name": "MemberAccess",
+                            "src": "1765:17:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 593,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "hashSigners"
+                                },
+                                "id": 598,
+                                "name": "Identifier",
+                                "src": "1765:11:2"
+                              }
+                            ]
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "hexvalue": "30",
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "subdenomination": null,
+                              "token": "number",
+                              "type": "int_const 0",
+                              "value": "0"
+                            },
+                            "id": 600,
+                            "name": "Literal",
+                            "src": "1785:1:2"
+                          }
+                        ],
+                        "id": 601,
+                        "name": "BinaryOperation",
+                        "src": "1765:21:2"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "string storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "type":
+                                "mapping(string memory => string storage ref)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 409,
+                                  "type": "bool",
+                                  "value": "proofs",
+                                  "commonType": {
+                                    "typeIdentifier": "t_uint256",
+                                    "typeString": "uint256"
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "<"
+                                },
+                                "id": 605,
+                                "name": "BinaryOperation",
+                                "src": "1806:28:2",
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 584,
+                                      "type": "uint256",
+                                      "value": "maxCount"
+                                    },
+                                    "id": 602,
+                                    "name": "Identifier",
+                                    "src": "1806:8:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "count",
+                                      "referencedDeclaration": 12,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 593,
+                                          "type":
+                                            "struct AddressSet.Data storage pointer",
+                                          "value": "hashSigners"
+                                        },
+                                        "id": 603,
+                                        "name": "Identifier",
+                                        "src": "1817:11:2"
+                                      }
+                                    ],
+                                    "id": 604,
+                                    "name": "MemberAccess",
+                                    "src": "1817:17:2"
+                                  }
+                                ]
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "sender",
+                                  "referencedDeclaration": null,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 693,
+                                      "type": "msg",
+                                      "value": "msg"
+                                    },
+                                    "id": 613,
+                                    "name": "ExpressionStatement",
+                                    "src": "1854:32:2",
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address[] memory"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 588,
+                                              "type": "address[] memory",
+                                              "value": "result"
+                                            },
+                                            "id": 606,
+                                            "name": "Identifier",
+                                            "src": "1854:6:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address[] memory",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_uint256",
+                                                      "typeString": "uint256"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": false,
+                                                  "isPure": true,
+                                                  "lValueRequested": false,
+                                                  "type":
+                                                    "function (uint256) pure returns (address[] memory)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "length": null,
+                                                      "type":
+                                                        "address[] storage pointer"
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "attributes": {
+                                                          "name": "address",
+                                                          "type": "address"
+                                                        },
+                                                        "id": 607,
+                                                        "name":
+                                                          "ElementaryTypeName",
+                                                        "src": "1867:7:2"
+                                                      }
+                                                    ],
+                                                    "id": 608,
+                                                    "name": "ArrayTypeName",
+                                                    "src": "1867:9:2"
+                                                  }
+                                                ],
+                                                "id": 609,
+                                                "name": "NewExpression",
+                                                "src": "1863:13:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 584,
+                                                  "type": "uint256",
+                                                  "value": "maxCount"
+                                                },
+                                                "id": 610,
+                                                "name": "Identifier",
+                                                "src": "1877:8:2"
+                                              }
+                                            ],
+                                            "id": 611,
+                                            "name": "FunctionCall",
+                                            "src": "1863:23:2"
+                                          }
+                                        ],
+                                        "id": 612,
+                                        "name": "Assignment",
+                                        "src": "1854:32:2"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "id": 614,
+                                "name": "Block",
+                                "src": "1836:65:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address[] memory"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 588,
+                                              "type": "address[] memory",
+                                              "value": "result"
+                                            },
+                                            "id": 615,
+                                            "name": "Identifier",
+                                            "src": "1925:6:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address[] memory",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_uint256",
+                                                      "typeString": "uint256"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": false,
+                                                  "isPure": true,
+                                                  "lValueRequested": false,
+                                                  "type":
+                                                    "function (uint256) pure returns (address[] memory)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "length": null,
+                                                      "type":
+                                                        "address[] storage pointer"
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "attributes": {
+                                                          "name": "address",
+                                                          "type": "address"
+                                                        },
+                                                        "id": 616,
+                                                        "name":
+                                                          "ElementaryTypeName",
+                                                        "src": "1938:7:2"
+                                                      }
+                                                    ],
+                                                    "id": 617,
+                                                    "name": "ArrayTypeName",
+                                                    "src": "1938:9:2"
+                                                  }
+                                                ],
+                                                "id": 618,
+                                                "name": "NewExpression",
+                                                "src": "1934:13:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "count",
+                                                  "referencedDeclaration": 12,
+                                                  "type": "uint256"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 593,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "hashSigners"
+                                                    },
+                                                    "id": 619,
+                                                    "name": "Identifier",
+                                                    "src": "1948:11:2"
+                                                  }
+                                                ],
+                                                "id": 620,
+                                                "name": "MemberAccess",
+                                                "src": "1948:17:2"
+                                              }
+                                            ],
+                                            "id": 621,
+                                            "name": "FunctionCall",
+                                            "src": "1934:32:2"
+                                          }
+                                        ],
+                                        "id": 622,
+                                        "name": "Assignment",
+                                        "src": "1925:41:2"
+                                      }
+                                    ],
+                                    "id": 623,
+                                    "name": "ExpressionStatement",
+                                    "src": "1925:41:2"
+                                  }
+                                ],
+                                "id": 624,
+                                "name": "Block",
+                                "src": "1907:74:2"
+                              }
+                            ],
+                            "id": 625,
+                            "name": "IfStatement",
+                            "src": "1802:179:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 539,
+                              "type": "string memory",
+                              "value": "method",
+                              "assignments": [627]
+                            },
+                            "id": 630,
+                            "name": "VariableDeclarationStatement",
+                            "src": "1995:34:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "constant": false,
+                                  "name": "current",
+                                  "scope": 660,
+                                  "stateVariable": false,
+                                  "storageLocation": "default",
+                                  "type": "address",
+                                  "value": null,
+                                  "visibility": "internal"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "name": "address",
+                                      "type": "address"
+                                    },
+                                    "id": 626,
+                                    "name": "ElementaryTypeName",
+                                    "src": "1995:7:2"
+                                  }
+                                ],
+                                "id": 627,
+                                "name": "VariableDeclaration",
+                                "src": "1995:15:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "head",
+                                  "referencedDeclaration": 8,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 593,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "hashSigners"
+                                    },
+                                    "id": 628,
+                                    "name": "Identifier",
+                                    "src": "2013:11:2"
+                                  }
+                                ],
+                                "id": 629,
+                                "name": "MemberAccess",
+                                "src": "2013:16:2"
+                              }
+                            ]
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "assignments": [632]
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "constant": false,
+                                      "name": "i",
+                                      "scope": 660,
+                                      "stateVariable": false,
+                                      "storageLocation": "default",
+                                      "type": "uint256",
+                                      "value": null,
+                                      "visibility": "internal"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "name": "uint256",
+                                          "type": "uint256"
+                                        },
+                                        "id": 631,
+                                        "name": "ElementaryTypeName",
+                                        "src": "2048:7:2"
+                                      }
+                                    ],
+                                    "id": 632,
+                                    "name": "VariableDeclaration",
+                                    "src": "2048:9:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 633,
+                                    "name": "Literal",
+                                    "src": "2060:1:2"
+                                  }
+                                ],
+                                "id": 634,
+                                "name": "VariableDeclarationStatement",
+                                "src": "2048:13:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "commonType": {
+                                    "typeIdentifier": "t_uint256",
+                                    "typeString": "uint256"
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "<",
+                                  "type": "bool"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 632,
+                                      "type": "uint256",
+                                      "value": "i"
+                                    },
+                                    "id": 635,
+                                    "name": "Identifier",
+                                    "src": "2063:1:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "length",
+                                      "referencedDeclaration": null,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 588,
+                                          "type": "address[] memory",
+                                          "value": "result"
+                                        },
+                                        "id": 636,
+                                        "name": "Identifier",
+                                        "src": "2067:6:2"
+                                      }
+                                    ],
+                                    "id": 637,
+                                    "name": "MemberAccess",
+                                    "src": "2067:13:2"
+                                  }
+                                ],
+                                "id": 638,
+                                "name": "BinaryOperation",
+                                "src": "2063:17:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "++",
+                                      "prefix": false,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 632,
+                                          "type": "uint256",
+                                          "value": "i"
+                                        },
+                                        "id": 639,
+                                        "name": "Identifier",
+                                        "src": "2082:1:2"
+                                      }
+                                    ],
+                                    "id": 640,
+                                    "name": "UnaryOperation",
+                                    "src": "2082:3:2"
+                                  }
+                                ],
+                                "id": 641,
+                                "name": "ExpressionStatement",
+                                "src": "2082:3:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": true,
+                                              "type": "address"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 588,
+                                                  "type": "address[] memory",
+                                                  "value": "result"
+                                                },
+                                                "id": 642,
+                                                "name": "Identifier",
+                                                "src": "2105:6:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 632,
+                                                  "type": "uint256",
+                                                  "value": "i"
+                                                },
+                                                "id": 643,
+                                                "name": "Identifier",
+                                                "src": "2112:1:2"
+                                              }
+                                            ],
+                                            "id": 644,
+                                            "name": "IndexAccess",
+                                            "src": "2105:9:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 627,
+                                              "type": "address",
+                                              "value": "current"
+                                            },
+                                            "id": 645,
+                                            "name": "Identifier",
+                                            "src": "2117:7:2"
+                                          }
+                                        ],
+                                        "id": 646,
+                                        "name": "Assignment",
+                                        "src": "2105:19:2"
+                                      }
+                                    ],
+                                    "id": 647,
+                                    "name": "ExpressionStatement",
+                                    "src": "2105:19:2"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 627,
+                                              "type": "address",
+                                              "value": "current"
+                                            },
+                                            "id": 648,
+                                            "name": "Identifier",
+                                            "src": "2142:7:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_address",
+                                                      "typeString": "address"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "getNext",
+                                                  "referencedDeclaration": 254,
+                                                  "type":
+                                                    "function (struct AddressSet.Data storage pointer,address) view returns (address)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 593,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "hashSigners"
+                                                    },
+                                                    "id": 649,
+                                                    "name": "Identifier",
+                                                    "src": "2152:11:2"
+                                                  }
+                                                ],
+                                                "id": 650,
+                                                "name": "MemberAccess",
+                                                "src": "2152:19:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 627,
+                                                  "type": "address",
+                                                  "value": "current"
+                                                },
+                                                "id": 651,
+                                                "name": "Identifier",
+                                                "src": "2172:7:2"
+                                              }
+                                            ],
+                                            "id": 652,
+                                            "name": "FunctionCall",
+                                            "src": "2152:28:2"
+                                          }
+                                        ],
+                                        "id": 653,
+                                        "name": "Assignment",
+                                        "src": "2142:38:2"
+                                      }
+                                    ],
+                                    "id": 654,
+                                    "name": "ExpressionStatement",
+                                    "src": "2142:38:2"
+                                  }
+                                ],
+                                "id": 655,
+                                "name": "Block",
+                                "src": "2087:108:2"
+                              }
+                            ],
+                            "id": 656,
+                            "name": "ForStatement",
+                            "src": "2043:152:2"
+                          }
+                        ],
+                        "id": 657,
+                        "name": "Block",
+                        "src": "1788:417:2"
+                      }
+                    ],
+                    "id": 658,
+                    "name": "IfStatement",
+                    "src": "1761:444:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 696,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 560,
+                            "name": "Identifier",
+                            "src": "1466:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "length",
+                                  "referencedDeclaration": null,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "isStructConstructorCall": false,
+                                      "lValueRequested": false,
+                                      "names": [null],
+                                      "type": "bytes storage ref",
+                                      "type_conversion": true
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": [
+                                            {
+                                              "typeIdentifier":
+                                                "t_string_storage_ptr",
+                                              "typeString":
+                                                "string storage pointer"
+                                            }
+                                          ],
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": true,
+                                          "lValueRequested": false,
+                                          "type": "type(bytes storage pointer)",
+                                          "value": "bytes"
+                                        },
+                                        "id": 561,
+                                        "name": "ElementaryTypeNameExpression",
+                                        "src": "1474:5:2"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 552,
+                                          "type": "string storage pointer",
+                                          "value": "value"
+                                        },
+                                        "id": 562,
+                                        "name": "Identifier",
+                                        "src": "1480:5:2"
+                                      }
+                                    ],
+                                    "id": 563,
+                                    "name": "FunctionCall",
+                                    "src": "1474:12:2"
+                                  }
+                                ],
+                                "id": 564,
+                                "name": "MemberAccess",
+                                "src": "1474:19:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "30",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 0",
+                                  "value": "0"
+                                },
+                                "id": 565,
+                                "name": "Literal",
+                                "src": "1496:1:2"
+                              }
+                            ],
+                            "id": 566,
+                            "name": "BinaryOperation",
+                            "src": "1474:23:2"
+                          }
+                        ],
+                        "id": 567,
+                        "name": "FunctionCall",
+                        "src": "1466:32:2"
+                      }
+                    ],
+                    "id": 568,
+                    "name": "ExpressionStatement",
+                    "src": "1466:32:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "delete",
+                          "prefix": true,
+                          "type": "tuple()"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "type": "string storage ref"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type":
+                                    "mapping(string memory => string storage ref)"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 409,
+                                      "type":
+                                        "mapping(address => mapping(string memory => string storage ref))",
+                                      "value": "proofs"
+                                    },
+                                    "id": 569,
+                                    "name": "Identifier",
+                                    "src": "1516:6:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "sender",
+                                      "referencedDeclaration": null,
+                                      "type": "address"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 693,
+                                          "type": "msg",
+                                          "value": "msg"
+                                        },
+                                        "id": 570,
+                                        "name": "Identifier",
+                                        "src": "1523:3:2"
+                                      }
+                                    ],
+                                    "id": 571,
+                                    "name": "MemberAccess",
+                                    "src": "1523:10:2"
+                                  }
+                                ],
+                                "id": 572,
+                                "name": "IndexAccess",
+                                "src": "1516:18:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 539,
+                                  "type": "string memory",
+                                  "value": "method"
+                                },
+                                "id": 573,
+                                "name": "Identifier",
+                                "src": "1535:6:2"
+                              }
+                            ],
+                            "id": 574,
+                            "name": "IndexAccess",
+                            "src": "1516:26:2"
+                          }
+                        ],
+                        "id": 575,
+                        "name": "UnaryOperation",
+                        "src": "1509:33:2"
+                      }
+                    ],
+                    "id": 576,
+                    "name": "ExpressionStatement",
+                    "src": "1509:33:2"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [null],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                },
+                                {
+                                  "typeIdentifier": "t_string_memory_ptr",
+                                  "typeString": "string memory"
+                                }
+                              ],
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 439,
+                              "type": "function (address,string memory)",
+                              "value": "ProofRemoved"
+                            },
+                            "id": 577,
+                            "name": "Identifier",
+                            "src": "1553:12:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 693,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 578,
+                                "name": "Identifier",
+                                "src": "1566:3:2"
+                              }
+                            ],
+                            "id": 579,
+                            "name": "MemberAccess",
+                            "src": "1566:10:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 539,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 580,
+                            "name": "Identifier",
+                            "src": "1578:6:2"
+                          }
+                        ],
+                        "id": 581,
+                        "name": "FunctionCall",
+                        "src": "1553:32:2"
+                      }
+                    ],
+                    "id": 582,
+                    "name": "ExpressionStatement",
+                    "src": "1553:32:2"
+                  }
+                ],
+                "id": 659,
+                "name": "Block",
+                "src": "1690:521:2"
+              }
+            ],
+            "id": 660,
+            "name": "FunctionDefinition",
+            "src": "1571:640:2"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "getProof",
+              "payable": false,
+              "scope": 677,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "signer",
+                      "scope": 676,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 661,
+                        "name": "ElementaryTypeName",
+                        "src": "2235:7:2"
+                      }
+                    ],
+                    "id": 662,
+                    "name": "VariableDeclaration",
+                    "src": "2235:14:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "method",
+                      "scope": 676,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 663,
+                        "name": "ElementaryTypeName",
+                        "src": "2251:6:2"
+                      }
+                    ],
+                    "id": 664,
+                    "name": "VariableDeclaration",
+                    "src": "2251:13:2"
+                  }
+                ],
+                "id": 665,
+                "name": "ParameterList",
+                "src": "2234:31:2"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 676,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "length": null,
+                          "type": "string storage pointer",
+                          "name": "string"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "name": "address",
+                              "type": "address"
+                            },
+                            "id": 590,
+                            "name": "ElementaryTypeName",
+                            "src": "1732:7:2"
+                          }
+                        ],
+                        "id": 666,
+                        "name": "ElementaryTypeName",
+                        "src": "2311:6:2"
+                      }
+                    ],
+                    "id": 667,
+                    "name": "VariableDeclaration",
+                    "src": "2311:6:2"
+                  }
+                ],
+                "id": 668,
+                "name": "ParameterList",
+                "src": "2310:8:2"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "assignments": [597],
+                      "functionReturnParameters": 668
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "hashSigners",
+                          "scope": 664,
+                          "stateVariable": false,
+                          "storageLocation": "storage",
+                          "type": "string storage ref",
+                          "value": null,
+                          "visibility": "internal",
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "contractScope": null,
+                              "name": "AddressSet.Data",
+                              "referencedDeclaration": 17,
+                              "type":
+                                "mapping(string memory => string storage ref)",
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false
+                            },
+                            "id": 671,
+                            "name": "IndexAccess",
+                            "src": "2340:14:2",
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 409,
+                                  "type":
+                                    "mapping(address => mapping(string memory => string storage ref))",
+                                  "value": "proofs"
+                                },
+                                "id": 669,
+                                "name": "Identifier",
+                                "src": "2340:6:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 662,
+                                  "type": "address",
+                                  "value": "signer"
+                                },
+                                "id": 670,
+                                "name": "Identifier",
+                                "src": "2347:6:2"
+                              }
+                            ]
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 664,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 672,
+                            "name": "Identifier",
+                            "src": "2355:6:2"
+                          }
+                        ],
+                        "id": 673,
+                        "name": "IndexAccess",
+                        "src": "2340:22:2"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "struct AddressSet.Data storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 403,
+                              "type":
+                                "mapping(bytes32 => struct AddressSet.Data storage ref)",
+                              "value": "signers"
+                            },
+                            "id": 598,
+                            "name": "Identifier",
+                            "src": "1802:7:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 586,
+                              "type": "bytes32",
+                              "value": "hash"
+                            },
+                            "id": 599,
+                            "name": "Identifier",
+                            "src": "1810:4:2"
+                          }
+                        ],
+                        "id": 600,
+                        "name": "IndexAccess",
+                        "src": "1802:13:2"
+                      }
+                    ],
+                    "id": 674,
+                    "name": "Return",
+                    "src": "2333:29:2"
+                  },
+                  {
+                    "attributes": {
+                      "falseBody": null
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": ">",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "count",
+                              "referencedDeclaration": 12,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 597,
+                                  "type":
+                                    "struct AddressSet.Data storage pointer",
+                                  "value": "hashSigners"
+                                },
+                                "id": 602,
+                                "name": "Identifier",
+                                "src": "1829:11:2"
+                              }
+                            ],
+                            "id": 603,
+                            "name": "MemberAccess",
+                            "src": "1829:17:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "hexvalue": "30",
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "subdenomination": null,
+                              "token": "number",
+                              "type": "int_const 0",
+                              "value": "0"
+                            },
+                            "id": 604,
+                            "name": "Literal",
+                            "src": "1849:1:2"
+                          }
+                        ],
+                        "id": 605,
+                        "name": "BinaryOperation",
+                        "src": "1829:21:2"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "commonType": {
+                                    "typeIdentifier": "t_uint256",
+                                    "typeString": "uint256"
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "<",
+                                  "type": "bool"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 588,
+                                      "type": "uint256",
+                                      "value": "maxCount"
+                                    },
+                                    "id": 606,
+                                    "name": "Identifier",
+                                    "src": "1870:8:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": true,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "count",
+                                      "referencedDeclaration": 12,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 597,
+                                          "type":
+                                            "struct AddressSet.Data storage pointer",
+                                          "value": "hashSigners"
+                                        },
+                                        "id": 607,
+                                        "name": "Identifier",
+                                        "src": "1881:11:2"
+                                      }
+                                    ],
+                                    "id": 608,
+                                    "name": "MemberAccess",
+                                    "src": "1881:17:2"
+                                  }
+                                ],
+                                "id": 609,
+                                "name": "BinaryOperation",
+                                "src": "1870:28:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address[] memory"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 592,
+                                              "type": "address[] memory",
+                                              "value": "result"
+                                            },
+                                            "id": 610,
+                                            "name": "Identifier",
+                                            "src": "1918:6:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address[] memory",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_uint256",
+                                                      "typeString": "uint256"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": false,
+                                                  "isPure": true,
+                                                  "lValueRequested": false,
+                                                  "type":
+                                                    "function (uint256) pure returns (address[] memory)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "length": null,
+                                                      "type":
+                                                        "address[] storage pointer"
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "attributes": {
+                                                          "name": "address",
+                                                          "type": "address"
+                                                        },
+                                                        "id": 611,
+                                                        "name":
+                                                          "ElementaryTypeName",
+                                                        "src": "1931:7:2"
+                                                      }
+                                                    ],
+                                                    "id": 612,
+                                                    "name": "ArrayTypeName",
+                                                    "src": "1931:9:2"
+                                                  }
+                                                ],
+                                                "id": 613,
+                                                "name": "NewExpression",
+                                                "src": "1927:13:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 588,
+                                                  "type": "uint256",
+                                                  "value": "maxCount"
+                                                },
+                                                "id": 614,
+                                                "name": "Identifier",
+                                                "src": "1941:8:2"
+                                              }
+                                            ],
+                                            "id": 615,
+                                            "name": "FunctionCall",
+                                            "src": "1927:23:2"
+                                          }
+                                        ],
+                                        "id": 616,
+                                        "name": "Assignment",
+                                        "src": "1918:32:2"
+                                      }
+                                    ],
+                                    "id": 617,
+                                    "name": "ExpressionStatement",
+                                    "src": "1918:32:2"
+                                  }
+                                ],
+                                "id": 618,
+                                "name": "Block",
+                                "src": "1900:65:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address[] memory"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 592,
+                                              "type": "address[] memory",
+                                              "value": "result"
+                                            },
+                                            "id": 619,
+                                            "name": "Identifier",
+                                            "src": "1989:6:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address[] memory",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_uint256",
+                                                      "typeString": "uint256"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": false,
+                                                  "isPure": true,
+                                                  "lValueRequested": false,
+                                                  "type":
+                                                    "function (uint256) pure returns (address[] memory)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "length": null,
+                                                      "type":
+                                                        "address[] storage pointer"
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "attributes": {
+                                                          "name": "address",
+                                                          "type": "address"
+                                                        },
+                                                        "id": 620,
+                                                        "name":
+                                                          "ElementaryTypeName",
+                                                        "src": "2002:7:2"
+                                                      }
+                                                    ],
+                                                    "id": 621,
+                                                    "name": "ArrayTypeName",
+                                                    "src": "2002:9:2"
+                                                  }
+                                                ],
+                                                "id": 622,
+                                                "name": "NewExpression",
+                                                "src": "1998:13:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "count",
+                                                  "referencedDeclaration": 12,
+                                                  "type": "uint256"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 597,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "hashSigners"
+                                                    },
+                                                    "id": 623,
+                                                    "name": "Identifier",
+                                                    "src": "2012:11:2"
+                                                  }
+                                                ],
+                                                "id": 624,
+                                                "name": "MemberAccess",
+                                                "src": "2012:17:2"
+                                              }
+                                            ],
+                                            "id": 625,
+                                            "name": "FunctionCall",
+                                            "src": "1998:32:2"
+                                          }
+                                        ],
+                                        "id": 626,
+                                        "name": "Assignment",
+                                        "src": "1989:41:2"
+                                      }
+                                    ],
+                                    "id": 627,
+                                    "name": "ExpressionStatement",
+                                    "src": "1989:41:2"
+                                  }
+                                ],
+                                "id": 628,
+                                "name": "Block",
+                                "src": "1971:74:2"
+                              }
+                            ],
+                            "id": 629,
+                            "name": "IfStatement",
+                            "src": "1866:179:2"
+                          },
+                          {
+                            "attributes": {
+                              "assignments": [631]
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "constant": false,
+                                  "name": "current",
+                                  "scope": 664,
+                                  "stateVariable": false,
+                                  "storageLocation": "default",
+                                  "type": "address",
+                                  "value": null,
+                                  "visibility": "internal"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "name": "address",
+                                      "type": "address"
+                                    },
+                                    "id": 630,
+                                    "name": "ElementaryTypeName",
+                                    "src": "2059:7:2"
+                                  }
+                                ],
+                                "id": 631,
+                                "name": "VariableDeclaration",
+                                "src": "2059:15:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "member_name": "head",
+                                  "referencedDeclaration": 8,
+                                  "type": "address"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 597,
+                                      "type":
+                                        "struct AddressSet.Data storage pointer",
+                                      "value": "hashSigners"
+                                    },
+                                    "id": 632,
+                                    "name": "Identifier",
+                                    "src": "2077:11:2"
+                                  }
+                                ],
+                                "id": 633,
+                                "name": "MemberAccess",
+                                "src": "2077:16:2"
+                              }
+                            ],
+                            "id": 634,
+                            "name": "VariableDeclarationStatement",
+                            "src": "2059:34:2"
+                          },
+                          {
+                            "children": [
+                              {
+                                "attributes": {
+                                  "assignments": [636]
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "constant": false,
+                                      "name": "i",
+                                      "scope": 664,
+                                      "stateVariable": false,
+                                      "storageLocation": "default",
+                                      "type": "uint256",
+                                      "value": null,
+                                      "visibility": "internal"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "name": "uint256",
+                                          "type": "uint256"
+                                        },
+                                        "id": 635,
+                                        "name": "ElementaryTypeName",
+                                        "src": "2112:7:2"
+                                      }
+                                    ],
+                                    "id": 636,
+                                    "name": "VariableDeclaration",
+                                    "src": "2112:9:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "hexvalue": "30",
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "lValueRequested": false,
+                                      "subdenomination": null,
+                                      "token": "number",
+                                      "type": "int_const 0",
+                                      "value": "0"
+                                    },
+                                    "id": 637,
+                                    "name": "Literal",
+                                    "src": "2124:1:2"
+                                  }
+                                ],
+                                "id": 638,
+                                "name": "VariableDeclarationStatement",
+                                "src": "2112:13:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "commonType": {
+                                    "typeIdentifier": "t_uint256",
+                                    "typeString": "uint256"
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "operator": "<",
+                                  "type": "bool"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [null],
+                                      "referencedDeclaration": 636,
+                                      "type": "uint256",
+                                      "value": "i"
+                                    },
+                                    "id": 639,
+                                    "name": "Identifier",
+                                    "src": "2127:1:2"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "member_name": "length",
+                                      "referencedDeclaration": null,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 592,
+                                          "type": "address[] memory",
+                                          "value": "result"
+                                        },
+                                        "id": 640,
+                                        "name": "Identifier",
+                                        "src": "2131:6:2"
+                                      }
+                                    ],
+                                    "id": 641,
+                                    "name": "MemberAccess",
+                                    "src": "2131:13:2"
+                                  }
+                                ],
+                                "id": 642,
+                                "name": "BinaryOperation",
+                                "src": "2127:17:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "++",
+                                      "prefix": false,
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [null],
+                                          "referencedDeclaration": 636,
+                                          "type": "uint256",
+                                          "value": "i"
+                                        },
+                                        "id": 643,
+                                        "name": "Identifier",
+                                        "src": "2146:1:2"
+                                      }
+                                    ],
+                                    "id": 644,
+                                    "name": "UnaryOperation",
+                                    "src": "2146:3:2"
+                                  }
+                                ],
+                                "id": 645,
+                                "name": "ExpressionStatement",
+                                "src": "2146:3:2"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": true,
+                                              "isPure": false,
+                                              "lValueRequested": true,
+                                              "type": "address"
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 592,
+                                                  "type": "address[] memory",
+                                                  "value": "result"
+                                                },
+                                                "id": 646,
+                                                "name": "Identifier",
+                                                "src": "2169:6:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 636,
+                                                  "type": "uint256",
+                                                  "value": "i"
+                                                },
+                                                "id": 647,
+                                                "name": "Identifier",
+                                                "src": "2176:1:2"
+                                              }
+                                            ],
+                                            "id": 648,
+                                            "name": "IndexAccess",
+                                            "src": "2169:9:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 631,
+                                              "type": "address",
+                                              "value": "current"
+                                            },
+                                            "id": 649,
+                                            "name": "Identifier",
+                                            "src": "2181:7:2"
+                                          }
+                                        ],
+                                        "id": 650,
+                                        "name": "Assignment",
+                                        "src": "2169:19:2"
+                                      }
+                                    ],
+                                    "id": 651,
+                                    "name": "ExpressionStatement",
+                                    "src": "2169:19:2"
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": false,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "operator": "=",
+                                          "type": "address"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [null],
+                                              "referencedDeclaration": 631,
+                                              "type": "address",
+                                              "value": "current"
+                                            },
+                                            "id": 652,
+                                            "name": "Identifier",
+                                            "src": "2206:7:2"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "isConstant": false,
+                                              "isLValue": false,
+                                              "isPure": false,
+                                              "isStructConstructorCall": false,
+                                              "lValueRequested": false,
+                                              "names": [null],
+                                              "type": "address",
+                                              "type_conversion": false
+                                            },
+                                            "children": [
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": [
+                                                    {
+                                                      "typeIdentifier":
+                                                        "t_address",
+                                                      "typeString": "address"
+                                                    }
+                                                  ],
+                                                  "isConstant": false,
+                                                  "isLValue": true,
+                                                  "isPure": false,
+                                                  "lValueRequested": false,
+                                                  "member_name": "getNext",
+                                                  "referencedDeclaration": 254,
+                                                  "type":
+                                                    "function (struct AddressSet.Data storage pointer,address) view returns (address)"
+                                                },
+                                                "children": [
+                                                  {
+                                                    "attributes": {
+                                                      "argumentTypes": null,
+                                                      "overloadedDeclarations": [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration": 597,
+                                                      "type":
+                                                        "struct AddressSet.Data storage pointer",
+                                                      "value": "hashSigners"
+                                                    },
+                                                    "id": 653,
+                                                    "name": "Identifier",
+                                                    "src": "2216:11:2"
+                                                  }
+                                                ],
+                                                "id": 654,
+                                                "name": "MemberAccess",
+                                                "src": "2216:19:2"
+                                              },
+                                              {
+                                                "attributes": {
+                                                  "argumentTypes": null,
+                                                  "overloadedDeclarations": [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration": 631,
+                                                  "type": "address",
+                                                  "value": "current"
+                                                },
+                                                "id": 655,
+                                                "name": "Identifier",
+                                                "src": "2236:7:2"
+                                              }
+                                            ],
+                                            "id": 656,
+                                            "name": "FunctionCall",
+                                            "src": "2216:28:2"
+                                          }
+                                        ],
+                                        "id": 657,
+                                        "name": "Assignment",
+                                        "src": "2206:38:2"
+                                      }
+                                    ],
+                                    "id": 658,
+                                    "name": "ExpressionStatement",
+                                    "src": "2206:38:2"
+                                  }
+                                ],
+                                "id": 659,
+                                "name": "Block",
+                                "src": "2151:108:2"
+                              }
+                            ],
+                            "id": 660,
+                            "name": "ForStatement",
+                            "src": "2107:152:2"
+                          }
+                        ],
+                        "id": 661,
+                        "name": "Block",
+                        "src": "1852:417:2"
+                      }
+                    ],
+                    "id": 662,
+                    "name": "IfStatement",
+                    "src": "1825:444:2"
+                  }
+                ],
+                "id": 675,
+                "name": "Block",
+                "src": "2323:46:2"
+              }
+            ],
+            "id": 676,
+            "name": "FunctionDefinition",
+            "src": "2217:152:2"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [null],
+              "name": "getProof",
+              "payable": false,
+              "scope": 681,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "signer",
+                      "scope": 680,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 665,
+                        "name": "ElementaryTypeName",
+                        "src": "2299:7:2"
+                      }
+                    ],
+                    "id": 666,
+                    "name": "VariableDeclaration",
+                    "src": "2299:14:2"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "method",
+                      "scope": 680,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 667,
+                        "name": "ElementaryTypeName",
+                        "src": "2315:6:2"
+                      }
+                    ],
+                    "id": 668,
+                    "name": "VariableDeclaration",
+                    "src": "2315:13:2"
+                  }
+                ],
+                "id": 669,
+                "name": "ParameterList",
+                "src": "2298:31:2"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 680,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "string memory",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "string",
+                          "type": "string storage pointer"
+                        },
+                        "id": 670,
+                        "name": "ElementaryTypeName",
+                        "src": "2375:6:2"
+                      }
+                    ],
+                    "id": 671,
+                    "name": "VariableDeclaration",
+                    "src": "2375:6:2"
+                  }
+                ],
+                "id": 672,
+                "name": "ParameterList",
+                "src": "2374:8:2"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 672
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "string storage ref"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "type":
+                                "mapping(string memory => string storage ref)"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 409,
+                                  "type":
+                                    "mapping(address => mapping(string memory => string storage ref))",
+                                  "value": "proofs"
+                                },
+                                "id": 673,
+                                "name": "Identifier",
+                                "src": "2404:6:2"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [null],
+                                  "referencedDeclaration": 666,
+                                  "type": "address",
+                                  "value": "signer"
+                                },
+                                "id": 674,
+                                "name": "Identifier",
+                                "src": "2411:6:2"
+                              }
+                            ],
+                            "id": 675,
+                            "name": "IndexAccess",
+                            "src": "2404:14:2"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [null],
+                              "referencedDeclaration": 668,
+                              "type": "string memory",
+                              "value": "method"
+                            },
+                            "id": 676,
+                            "name": "Identifier",
+                            "src": "2419:6:2"
+                          }
+                        ],
+                        "id": 677,
+                        "name": "IndexAccess",
+                        "src": "2404:22:2"
+                      }
+                    ],
+                    "id": 678,
+                    "name": "Return",
+                    "src": "2397:29:2"
+                  }
+                ],
+                "id": 679,
+                "name": "Block",
+                "src": "2387:46:2"
+              }
+            ],
+            "id": 680,
+            "name": "FunctionDefinition",
+            "src": "2281:152:2"
+          }
+        ],
+        "id": 677,
+        "name": "ContractDefinition",
+        "src": "54:2317:2"
+      }
+    ],
+    "id": 678,
+    "name": "SourceUnit",
+    "src": "0:2372:2"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
+  },
+  "networks": {},
+  "schemaVersion": "1.0.1",
+  "updatedAt": "2017-11-04T18:31:33.334Z"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
     "@types/yargs": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw=="
+      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "dev": true
     },
     "acorn": {
       "version": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,9 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
+    "bignumber.js": {
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+    },
     "binary-extensions": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
@@ -669,6 +672,11 @@
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
       }
+    },
+    "crypto-js": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
     },
     "d": {
       "version": "1.0.0",
@@ -1106,6 +1114,23 @@
       "integrity": "sha512-zVipEeZQcBnOzpGQk4ngFbd+VUYJDWASnGpquHthSPta3Kcy33qOwAIx3hXRmDdp4d2zbm8licximJWbpEG1hA==",
       "requires": {
         "webpack": "3.8.1"
+      }
+    },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
       }
     },
     "event-emitter": {
@@ -1782,6 +1807,11 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -1948,6 +1978,11 @@
           }
         }
       }
+    },
+    "js-sha3": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2779,6 +2814,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3737,6 +3788,14 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
+    },
     "strip-indent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
@@ -3903,6 +3962,41 @@
         "solc": "0.4.18"
       }
     },
+    "truffle-blockchain-utils": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz",
+      "integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
+      "requires": {
+        "web3": "0.20.2"
+      }
+    },
+    "truffle-contract": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.1.tgz",
+      "integrity": "sha512-uHavvQfKuPRCxk1v+jjbGuxpng0EgyLOF3wASrIrkHHiv2aUZiZr+z0EHyUOSrq4aAKeA8CqpToUyFrGGHXJNA==",
+      "requires": {
+        "ethjs-abi": "0.1.8",
+        "truffle-blockchain-utils": "0.0.3",
+        "truffle-contract-schema": "1.0.1",
+        "web3": "0.20.2"
+      }
+    },
+    "truffle-contract-schema": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-1.0.1.tgz",
+      "integrity": "sha512-37ZO9FVvmW/PZz/sh00LAz7HN2U4FHERuxI4mCbUR6h3r2cRgZ4YBfzHuAHOnZlrVzM1qx/Dx/1Ng3UyfWseEA==",
+      "requires": {
+        "ajv": "5.3.0",
+        "crypto-js": "3.1.9-1"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "3.1.9-1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+        }
+      }
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -4043,6 +4137,11 @@
         }
       }
     },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -4088,6 +4187,18 @@
         "async": "2.5.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
+      }
+    },
+    "web3": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.2.tgz",
+      "integrity": "sha1-xU2sX8DjdzmcBMGm7LsS5FEyeNY=",
+      "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "crypto-js": "3.1.8",
+        "utf8": "2.1.2",
+        "xhr2": "0.1.4",
+        "xmlhttprequest": "1.8.0"
       }
     },
     "webpack": {
@@ -4235,6 +4346,16 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
+    },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "homepage": "https://github.com/SignHash/signhash-contracts#readme",
   "dependencies": {
-    "@types/yargs": "^8.0.2",
     "ethereumjs-testrpc": "^4.1.3",
     "truffle": "^4.0.0",
     "yargs": "^9.0.1"
@@ -56,6 +55,7 @@
     "@types/chai": "^4.0.4",
     "@types/mocha": "^2.2.43",
     "@types/ramda": "^0.24.14",
+    "@types/yargs": "^8.0.2",
     "husky": "^0.14.3",
     "lint-staged": "^4.2.2",
     "npm-run-all": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test:js":
       "truffle test --contracts_build_directory .cache/contracts test/*.js",
     "migrate": "truffle migrate --reset --network testrpc",
-    "testrpc":
-      "testrpc --mnemonic \"try exile adapt shed width laugh similar duty neglect kick rug require\"",
+    "testrpc": "node ./testrpc/index.js",
+    "testrpc:deploy": "npm run testrpc -- --deploy",
     "seed": "run-p testrpc migrate",
     "lint": "run-p -c --aggregate-output lint:solhint lint:tslint",
     "lint:tslint": "tslint *.ts migrations/*.ts test/*.ts",
@@ -48,6 +48,8 @@
   "dependencies": {
     "ethereumjs-testrpc": "^4.1.3",
     "truffle": "^4.0.0",
+    "truffle-contract": "^3.0.1",
+    "web3": "^0.20.2",
     "yargs": "^9.0.1"
   },
   "devDependencies": {

--- a/testrpc/index.js
+++ b/testrpc/index.js
@@ -1,0 +1,66 @@
+const Web3 = require('web3');
+const TestRPC = require('ethereumjs-testrpc');
+const buildContract = require('truffle-contract');
+const path = require('path');
+const argv = require('yargs')
+      .option('deploy')
+      .argv;
+
+const DEPLOY = !!argv.deploy;
+const RPC_PORT = 8545;
+const ABI_DIR = path.join(__dirname, '../build/contracts');
+
+const MNEMONIC =
+      'try exile adapt shed width laugh similar duty neglect kick rug require';
+
+
+async function run() {
+  const provider = new Web3.providers.HttpProvider(
+    'http://localhost:' + RPC_PORT
+  );
+  const web3 = new Web3(provider);
+  const server = TestRPC.server({
+    mnemonic: MNEMONIC,
+    secure: false,
+    logger: console,
+    gasLimit: 10e8,
+  });
+
+  server.listen(RPC_PORT, async (listenErr, state) => {
+    if (listenErr) {
+      console.error(
+        `Failed to start TestRPC server on port ${RPC_PORT}: `,
+        listenErr
+      );
+      return;
+    }
+
+    web3.settings.defaultAccount = Object.keys(state.accounts)[0];
+    web3.eth.defaultAccount = Object.keys(state.accounts)[0];
+    console.log(`TestRPC server started on port ${RPC_PORT}`);
+
+    if (DEPLOY) {
+      await deploy(provider);
+      console.log('Migrations completed');
+    }
+
+    console.log('TestRPC is Ready');
+  });
+}
+
+
+async function deploy(provider) {
+  const signHashContract = getContract(provider, 'SignHash');
+  await signHashContract.new({ gas: 10e6 });
+}
+
+
+function getContract(provider, contractName) {
+  const abi = require(path.join(ABI_DIR, contractName + '.json'));
+  const contract = buildContract(abi);
+  contract.setProvider(provider);
+  return contract;
+}
+
+
+run();


### PR DESCRIPTION
As you may notice it does not use truffle migrations. It turns out that using *.ts files for migrations is a problem when package is a dependency of another package (upstream would have to install typescript and run tsc before running any migrations). 
I wanted to keep it as simple as possible and just deploying contract in testrpc directly does the job well. Additional benefit is that we don't have to mess with truffle internals, initialize config by hand and pin `truffle-*` dependencies, so I'm quite happy with this solution.

I've also compiled the ABIs as they are needed by the frontend app.